### PR TITLE
Add DerivingVia support on ghc>=8.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ with `ghc-source-gen` should compile unchanged on each of those versions.
 
 Currently, this library supports GHC versions 8.2, 8.4, 8.6 and 8.8.
 
-One caveat: in the future, `ghc-source-gen` will support some forms of syntax
+One caveat: `ghc-source-gen` supports some forms of syntax
 which are not implemented by all of those GHC versions.  For example, the
 `DerivingVia` extension is only implemented in `ghc >= 8.6`.  When built on
 older versions of GHC, `ghc-source-gen` will omit functions for constructing
-that syntax.  We will also tag any such function with a note in its Haddock
-documentation.
+that syntax (for example: `GHC.SourceGen.Decl.derivingVia`).  We will also tag
+any such function with a note in its Haddock documentation.
 
 ### Less verbose types and construction functions
 

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -27,6 +27,9 @@ module GHC.SourceGen.Decl
     , derivingStock
     , derivingAnyclass
     , derivingNewtype
+#if MIN_VERSION_ghc(8,6,0)
+    , derivingVia
+#endif
       -- * Class declarations
     , class'
     , ClassDecl
@@ -348,3 +351,14 @@ derivingNewtype = derivingWay (Just NewtypeStrategy)
 
 derivingAnyclass :: [HsType'] -> HsDerivingClause'
 derivingAnyclass = derivingWay (Just AnyclassStrategy)
+
+#if MIN_VERSION_ghc(8,6,0)
+-- | A `DerivingVia` clause.
+--
+-- > deriving (Eq, Show) via T
+-- > =====
+-- > derivingVia (var "T") [var "Eq", var "Show"]
+-- Available with `ghc >= 8.6`.
+derivingVia :: HsType' -> [HsType'] -> HsDerivingClause'
+derivingVia t = derivingWay (Just $ ViaStrategy $ sigType t)
+#endif


### PR DESCRIPTION
Serves as an example for how we support features that only work
on new enough GHC versions.