### PR TITLE
Make ghc-show-ast independent of ghc-exactprint.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - stack-cache-v2-11.22-{{ arch }}-{{ .Branch }}
             - stack-cache-v2-11.22-{{ arch }}-master
     - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-11.22 ghc-source-gen
+    - run: stack test --no-terminal --resolver=lts-11.22
     - save_cache:
             key: stack-cache-v2-11.22-{{ arch }}-{{ .Branch }}-{{ epoch }}
             paths:
@@ -27,7 +27,7 @@ jobs:
             - stack-cache-v2-12.8-{{ arch }}-{{ .Branch }}
             - stack-cache-v2-12.8-{{ arch }}-master
     - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-12.8 ghc-source-gen
+    - run: stack test --no-terminal --resolver=lts-12.8
     - save_cache:
             key: stack-cache-v2-12.8-{{ arch }}-{{ .Branch }}-{{ epoch }}
             paths:
@@ -43,7 +43,7 @@ jobs:
             - stack-cache-v2-13.23-{{ arch }}-{{ .Branch }}
             - stack-cache-v2-13.23-{{ arch }}-master
     - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-13.23 ghc-source-gen
+    - run: stack test --no-terminal --resolver=lts-13.23
     - save_cache:
             key: stack-cache-v2-13.23-{{ arch }}-{{ .Branch }}-{{ epoch }}
             paths:
@@ -60,7 +60,7 @@ jobs:
             - stack-cache-v2-ghc-8.8-{{ arch }}-{{ .Branch }}
             - stack-cache-v2-ghc-8.8-{{ arch }}-master
     - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --stack-yaml=stack-8.8.yaml ghc-source-gen
+    - run: stack test --no-terminal --stack-yaml=stack-8.8.yaml
     - save_cache:
             key: stack-cache-v2-ghc-8.8-{{ arch }}-{{ .Branch }}-{{ epoch }}
             paths:

--- a/check.sh
+++ b/check.sh
@@ -13,5 +13,5 @@ set -ueo pipefail
 for flag in --resolver={lts-11.22,lts-12.8,lts-13.23} --stack-yaml=stack-8.8.yaml
 do
     echo ====== $flag ======
-    stack test --no-terminal $flag ghc-source-gen
+    stack test --no-terminal $flag
 done

--- a/ghc-show-ast/package.yaml
+++ b/ghc-show-ast/package.yaml
@@ -12,5 +12,5 @@ executables:
     dependencies:
     - base
     - ghc
-    - ghc-exactprint
+    - ghc-paths
     - pretty


### PR DESCRIPTION
Lets us build it with (unreleased) ghc-8.8.  Also makes it possible
to test in CI without adding more dependencies.