### PR TITLE
Introduce `valBind`, and add `HasPatBind`.

### DIFF
--- a/src/GHC/SourceGen/Binds/Internal.hs
+++ b/src/GHC/SourceGen/Binds/Internal.hs
@@ -10,6 +10,7 @@ module GHC.SourceGen.Binds.Internal where
 import BasicTypes (Origin(Generated))
 import Bag (listToBag)
 import HsBinds
+import HsDecls
 import HsExpr (MatchGroup(..), Match(..), GRHSs(..))
 import SrcLoc (Located)
 
@@ -104,3 +105,25 @@ mkGRHSs g = noExt GRHSs
 -- > | otherwise = ()
 type GuardedExpr = GRHS' (Located HsExpr')
 
+-- | Syntax types which can declare/define functions.  For example:
+-- declarations, or the body of a class declaration or class instance.
+--
+-- To declare the type of a function or value, use
+-- 'GHC.SourceGen.Binds.typeSig' or 'GHC.SourceGen.Binds.typeSigs'.
+--
+-- To define a function, use 
+-- 'GHC.SourceGen.Binds.funBind' or 'GHC.SourceGen.Binds.funBinds'.
+--
+-- To define a value, use
+-- 'GHC.SourceGen.Binds.valBind' or 'GHC.SourceGen.Binds.valBindRhs'.
+class HasValBind t where
+    sigB :: Sig' -> t
+    bindB :: HsBind' -> t
+
+instance HasValBind HsDecl' where
+    sigB = noExt SigD
+    bindB = noExt ValD
+
+instance HasValBind RawValBind where
+    sigB = SigV
+    bindB = BindV

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -67,7 +67,7 @@ import HsExtension (NoExt(NoExt))
 import PlaceHolder (PlaceHolder(..))
 #endif
 
-import GHC.SourceGen.Binds hiding (patBind)
+import GHC.SourceGen.Binds.Internal
 import GHC.SourceGen.Lit.Internal (noSourceText)
 import GHC.SourceGen.Name
 import GHC.SourceGen.Name.Internal

--- a/src/GHC/SourceGen/Syntax/Internal.hs
+++ b/src/GHC/SourceGen/Syntax/Internal.hs
@@ -169,6 +169,7 @@ type HsExpr' = HsExpr RdrName
 -- Instances:
 --
 -- * 'GHC.SourceGen.Binds.HasValBind'
+-- * 'GHC.SourceGen.Binds.HasPatBind'
 #if MIN_VERSION_ghc(8,4,0)
 type HsDecl' = HsDecl GhcPs
 #else

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -174,6 +174,16 @@ declsTest dflags = testGroup "Decls"
                         unit
                     ]
         ]
+    , test "valBind"
+        [ "x = y" :~ valBind "x" $ rhs $ var "y"
+        , "x = y" :~ valBindRhs "x" $ var "y"
+        , "x | test = 1\n  | otherwise = 2" :~
+            valBind "x"
+            $ guardedRhs
+                [ var "test" `guard` int 1
+                , var "otherwise" `guard` int 2
+                ]
+        ]
     , test "funBind"
         [ "not True = False\nnot False = True" :~
              funBinds "not"


### PR DESCRIPTION
Another follow-up fix for #13:
- Don't allow pattern bindings in class or instance declarations
- Add `valBind` which *is* allowed in let and where clauses
- Add `valBindRhs` and `patBindRhs`.
- Hide the constructors of `HasValBind`
