### PR TITLE
Replace matchRhs/matchRhs with match/matchGRHSs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ constModule :: HsModule'
 constModule =
     module' (Just "Const") (Just [var "const"]) []
         [ typeSig "const" $ a --> b --> a
-        , funBind "const" $ matchRhs [wildP, x] x
+        , funBind "const" $ match [wildP, x] x
         ]
   where
     a = var "a"

--- a/src/GHC/SourceGen/Binds/Internal.hs
+++ b/src/GHC/SourceGen/Binds/Internal.hs
@@ -115,7 +115,7 @@ type GuardedExpr = GRHS' (Located HsExpr')
 -- 'GHC.SourceGen.Binds.funBind' or 'GHC.SourceGen.Binds.funBinds'.
 --
 -- To define a value, use
--- 'GHC.SourceGen.Binds.valBind' or 'GHC.SourceGen.Binds.valBindRhs'.
+-- 'GHC.SourceGen.Binds.valBind' or 'GHC.SourceGen.Binds.valBindGuarded'.
 class HasValBind t where
     sigB :: Sig' -> t
     bindB :: HsBind' -> t

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -127,7 +127,7 @@ funDep = ClassFunDep
 -- >      [ typeSig "divMod" $ a --> a --> tuple [a, a]
 -- >      , typeSig "div" $ a --> a --> a
 -- >      , funBind "div"
--- >          $ matchRhs [var "x", var "y"]
+-- >          $ match [var "x", var "y"]
 -- >             $ var "fst" @@ (var "divMod" @@ var "x" @@ var "y")
 -- >      ]
 class'
@@ -181,8 +181,8 @@ instance HasValBind RawInstDecl where
 -- > instance' (var "Show" @@ var "Bool")
 -- >   [ typeSig "show" $ var "Bool" --> var "String"
 -- >   , funBinds "show"
--- >       [ matchRhs [var "True"] $ string "True"
--- >       , matchRhs [var "False"] $ string "False"
+-- >       [ match [var "True"] $ string "True"
+-- >       , match [var "False"] $ string "False"
 -- >       ]
 -- >   ]
 instance' :: HsType' -> [RawInstDecl] -> HsDecl'

--- a/src/GHC/SourceGen/Expr.hs
+++ b/src/GHC/SourceGen/Expr.hs
@@ -56,7 +56,7 @@ case' e matches = noExt HsCase (builtLoc e)
                     $ matchGroup CaseAlt matches
 
 lambda :: [Pat'] -> HsExpr' -> HsExpr'
-lambda ps e = noExt HsLam $ matchGroup LambdaExpr [matchRhs ps e]
+lambda ps e = noExt HsLam $ matchGroup LambdaExpr [match ps e]
 
 lambdaCase :: [RawMatch] -> HsExpr'
 lambdaCase = noExt HsLamCase . matchGroup CaseAlt

--- a/tests/pprint_examples.hs
+++ b/tests/pprint_examples.hs
@@ -30,7 +30,7 @@ test1 = pprint $ tuple
     , char 'g'
     , let' [ typeSig "result" $ var "A" @@ var "B"
            , funBind "result"
-                $ matchRhs [var "x", wildP]
+                $ match [var "x", wildP]
                     $ var "foo" @@ char 'c'
            ]
         (var "result")
@@ -40,37 +40,37 @@ test2 :: IO ()
 test2 = pprint $ module' (Just "Foo") (Just [var "efg"]) []
     [ typeSigs ["efg", "h"] $ tuple [var "A", var "B"]
     , funBind "efg"
-        $ match []
+        $ matchGRHSs []
         $ rhs (char 'a')
             `where'` [ typeSig "q" $ var "Q"
-                     , funBind "q" $ match []
+                     , funBind "q" $ matchGRHSs []
                         $ guardedRhs [var "True" `guard` char 'q']
                      ]
     , funBind "f"
-        $ match [var "x", var "y"]
+        $ matchGRHSs [var "x", var "y"]
         $ rhs
             (case' (var "y")
-                        [matchRhs [wildP] $ var "x"])
-            `where'` [funBind "q" $ matchRhs [] $ char 't']
+                        [match [wildP] $ var "x"])
+            `where'` [funBind "q" $ match [] $ char 't']
     ]
 
 test3 :: IO ()
 test3 = pprint $ module' Nothing Nothing []
-    [ funBind "lambdas" $ matchRhs [] $ lambda [var "y"]
-                    $ lambdaCase [matchRhs [var "z"] (char 'a')]
+    [ funBind "lambdas" $ match [] $ lambda [var "y"]
+                    $ lambdaCase [match [var "z"] (char 'a')]
     , funBinds "ifs"
-        [ matchRhs [var "x"] $ if' (var "b") (var "t") (var "f")
-        , matchRhs [var "y"] $ multiIf [guard (var "False") $ char 'f'
+        [ match [var "x"] $ if' (var "b") (var "t") (var "f")
+        , match [var "y"] $ multiIf [guard (var "False") $ char 'f'
                                        , guard (var "True") $ char 't'
                                        ]
-        , matchRhs [var "z"] $ multiIf
+        , match [var "z"] $ multiIf
             [ guard (var "f" @@ var "x") $ string "f"
             , guard (var "g" @@ var "x") $ string "g"
             , guard (var "otherwise") $ string "h"
             ]
         ]
     , funBind "do'"
-        $ matchRhs [] (do' [ var "x" <-- var "act"
+        $ match [] (do' [ var "x" <-- var "act"
                         , stmt $ var "return" @@ var "x"
                         ])
     , typeSig "types"
@@ -81,34 +81,34 @@ test3 = pprint $ module' Nothing Nothing []
             (forall' [var "x", var "y"]
                 $ var "y")
     , funBind "swap"
-        $ matchRhs [tuple [var "x", var "y"]]
+        $ match [tuple [var "x", var "y"]]
             $ tuple [var "y", var "x"]
-    , funBind "char" $ matchRhs [char 'a'] (char 'b')
-    , funBind "string" $ matchRhs [string "abc"] (string "def")
+    , funBind "char" $ match [char 'a'] (char 'b')
+    , funBind "string" $ match [string "abc"] (string "def")
     , funBind "as"
-        $ matchRhs [asP "x" (tuple [var "y", var "z"])]
+        $ match [asP "x" (tuple [var "y", var "z"])]
             (var "x")
     , funBind "con"
-        $ matchRhs [conP "A" [var "b", conP "C" [var "d"]]]
+        $ match [conP "A" [var "b", conP "C" [var "d"]]]
             $ tuple [var "b", var "d"]
     , funBind "ops"
-        $ matchRhs [var "x", var "y"]
+        $ match [var "x", var "y"]
             $ op (var "x") "+" (var "y")
     , funBinds "ops'"
-        [ matchRhs [] (op (int 1) "*"
+        [ match [] (op (int 1) "*"
                         (op (int 2) "+" (int 3)))
-        , matchRhs [] (op (var "A" @@ var "x") "*"
+        , match [] (op (var "A" @@ var "x") "*"
                         (op (var "B" @@ var "y") "+"
                                  (var "C" @@ var "z")))
-        , matchRhs [] (op (var "A" @@ var "x") "mult"
+        , match [] (op (var "A" @@ var "x") "mult"
                         (op (var "B" @@ var "y") "+"
                                  (var "C" @@ var "z")))
         ]
     , funBinds "cons'"
-        [ matchRhs [] (var "X" @@ int 1 @@
+        [ match [] (var "X" @@ int 1 @@
                         (var "Y" @@ int 2 @@ int 3)
                         @@ var "Z")
-        , matchRhs [] (var "f" @@ par (var "g" @@ var "x"))
+        , match [] (var "f" @@ par (var "g" @@ var "x"))
         ]
     , typeSig "f" $ var "X" @@ var "a" @@
                         (var "Y" @@ var "b" @@ var "c")
@@ -118,7 +118,7 @@ test3 = pprint $ module' Nothing Nothing []
                                  (var "C" @@ var "z"))
     , class' [var "A" @@ var "a"] "B" ["b", "b'"]
         [ typeSig "f" $ var "b" --> var "b'"
-        , funBind "f" $ matchRhs [] $ var "id"
+        , funBind "f" $ match [] $ var "id"
         ]
     , class' [] "F" ["a", "b", "c"]
         [ funDep ["a", "b"] ["c"]
@@ -139,7 +139,7 @@ test3 = pprint $ module' Nothing Nothing []
         [deriving' [var "X", var "Y"]]
     , instance' (var "A" @@ var "b" @@ var "c")
         [ typeSig "f" $ var "b" --> var "c"
-        , funBind "f" $ matchRhs [] $ var "undefined"
+        , funBind "f" $ match [] $ var "undefined"
         ]
     , let a = var "a"
       in class'
@@ -149,14 +149,14 @@ test3 = pprint $ module' Nothing Nothing []
            [ typeSig "divMod" $ a --> a --> tuple [a, a]
            , typeSig "div" $ a --> a --> a
            , funBind "div"
-               $ matchRhs [var "x", var "y"]
+               $ match [var "x", var "y"]
                   $ var "fst" @@ (var "divMod" @@ var "x" @@ var "y")
            ]
     , instance' (var "Show" @@ var "Bool")
         [ typeSig "show" $ var "Bool" --> var "String"
         , funBinds "show"
-            [ matchRhs [var "True"] $ string "True"
-            , matchRhs [var "False"] $ string "False"
+            [ match [var "True"] $ string "True"
+            , match [var "False"] $ string "False"
             ]
         ]
     , data' "X" ["b"]
@@ -191,12 +191,12 @@ test3 = pprint $ module' Nothing Nothing []
         ]
         []
     , funBind "strictness"
-        $ matchRhs
+        $ match
             [strictP (conP "A" [var "b"]),
              lazyP (conP "A" [var "b"])
             ] (char 'x')
     , typeSig "unit" $ unit --> unit
-    , funBind "unit" $ matchRhs [unit] unit
+    , funBind "unit" $ match [unit] unit
     ]
 
 test4 :: IO ()
@@ -219,7 +219,7 @@ test5 = pprint $ module' (Just "M") (Just exports) imports []
 constModule :: HsModule'
 constModule = module' (Just "Const") (Just [var "const"]) []
     [ typeSig "const" $ a --> b --> a
-    , funBind "const" $ matchRhs [wildP, x] x
+    , funBind "const" $ match [wildP, x] x
     ]
   where
     a = var "a"

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -155,17 +155,17 @@ exprsTest dflags = testGroup "Expr"
 
 declsTest dflags = testGroup "Decls"
     [ test "patBind"
-        [ "x = x" :~ patBind (var "x") (rhs $ var "x")
+        [ "x = x" :~ patBind (var "x") (var "x")
         , "(x, y) = (y, x)" :~ patBind (tuple [var "x", var "y"])
-                                    (rhs $ tuple [var "y", var "x"])
+                                    (tuple [var "y", var "x"])
         , "(x, y)\n  | test = (1, 2)\n  | otherwise = (2, 3)" :~
-            patBind (tuple [var "x", var "y"])
+            patBindGRHSs (tuple [var "x", var "y"])
                 $ guardedRhs
                     [ var "test" `guard` tuple [int 1, int 2]
                         , var "otherwise" `guard` tuple [int 2, int 3]
                     ]
         , "z | Just y <- x, y = ()" :~
-            patBind (var "z")
+            patBindGRHSs (var "z")
                 $ guardedRhs
                     [guards
                         [ conP "Just" [var "y"] <-- var "x"
@@ -175,10 +175,10 @@ declsTest dflags = testGroup "Decls"
                     ]
         ]
     , test "valBind"
-        [ "x = y" :~ valBind "x" $ rhs $ var "y"
-        , "x = y" :~ valBindRhs "x" $ var "y"
+        [ "x = y" :~ valBindGRHSs "x" $ rhs $ var "y"
+        , "x = y" :~ valBind "x" $ var "y"
         , "x | test = 1\n  | otherwise = 2" :~
-            valBind "x"
+            valBindGRHSs "x"
             $ guardedRhs
                 [ var "test" `guard` int 1
                 , var "otherwise" `guard` int 2
@@ -187,12 +187,12 @@ declsTest dflags = testGroup "Decls"
     , test "funBind"
         [ "not True = False\nnot False = True" :~
              funBinds "not"
-                [ matchRhs [var "True"] (var "False")
-                , matchRhs [var "False"] (var "True")
+                [ match [var "True"] (var "False")
+                , match [var "False"] (var "True")
                 ]
         , "not x\n  | x = False\n  | otherwise = True" :~
             funBind "not"
-                $ match [var "x"] $ guardedRhs
+                $ matchGRHSs [var "x"] $ guardedRhs
                     [ guard (var "x") (var "False")
                     , guard (var "otherwise") (var "True")
                     ]


### PR DESCRIPTION
Optimize names for the common case taking just an expression
on the RHS.

Also for `valBind` and `patBind`.