### PR TITLE
Parenthesize let-expressions inside of do-expressions.

### DIFF
--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -174,6 +174,10 @@ exprsTest dflags = testGroup "Expr"
         , "x + y {b = x}"
             :~ op (var "x") "+" (recordUpd (var "y") [("b", var "x")])
         ]
+    , test "do"
+        -- TODO: add more tests.
+        [ "do (let x = 1 in x)" :~ do' [stmt $ let' [valBind "x" (int 1)] (var "x")]
+        ]
     ]
   where
     test = testExprs dflags


### PR DESCRIPTION
The following syntax is not valid, but can be generated by GHC;

```
do let ...
   in ...
```

It's not always a problem, if GHC manages to wrap it like

```
do let ... in ...
```

But for consistency, and since this ought to be an uncommon case,
always wrap `let`s in parentheses when they're inside of a `do` statement.