### PR TITLE
Make tyApp's precedence match -XTypeApplications.

### DIFF
--- a/src/GHC/SourceGen/Expr.hs
+++ b/src/GHC/SourceGen/Expr.hs
@@ -134,7 +134,7 @@ tyApp e t = HsAppType e' t'
 #endif
   where
     t' = wcType $ unLoc $ parenthesizeTypeForApp $ builtLoc t
-    e' = parenthesizeExprForApp $ builtLoc e
+    e' = builtLoc e
 
 -- | Constructs a record with explicit field names.
 --

--- a/src/GHC/SourceGen/Expr/Internal.hs
+++ b/src/GHC/SourceGen/Expr/Internal.hs
@@ -52,6 +52,7 @@ needsExprForOp e = case e of
     _ -> False
 needsExprForApp e = case e of
     HsApp{} -> True
+    HsAppType{} -> True
     HsStatic{} -> True
     _ -> needsExprForOp e
 

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -129,6 +129,8 @@ exprsTest dflags = testGroup "Expr"
         , "(\\ x -> x) (\\ x -> x)" :~
             let f = lambda [var "x"] (var "x")
             in f @@ f
+        , "f x @t" :~ tyApp (var "f" @@ var "x") (var "t")
+        , "f (x @t)" :~ var "f" @@ (tyApp (var "x") (var "t"))
         ]
     , test "op"
         [ "x + y" :~ op (var "x") "+" (var "y")
@@ -143,6 +145,8 @@ exprsTest dflags = testGroup "Expr"
         , "(\\ x -> x) . (\\ x -> x)" :~
             let f = lambda [var "x"] (var "x")
             in op f "." f
+        , "x @s + y @t" :~
+                op (var "x" `tyApp` var "s") "+" (var "y" `tyApp` var "t")
         ]
     , test "period-op"
         [ "(Prelude..) x" :~ var "Prelude.." @@ var "x"
@@ -167,6 +171,8 @@ exprsTest dflags = testGroup "Expr"
         , "x @a b" :~ tyApp (var "x") (var "a") @@ var "b"
         , "x @(a b)" :~ tyApp (var "x") (var "a" @@ var "b")
         , "x @(a + b)" :~ tyApp (var "x") (op (var "a") "+" (var "b"))
+        , "f x @t" :~ (var "f" @@ var "x") `tyApp` var "t"
+        , "f (x @t)" :~ var "f" @@ (var "x" `tyApp` var "t")
         ]
     , test "recordConE"
         [ "A {}" :~ recordConE "A" []
@@ -194,11 +200,6 @@ exprsTest dflags = testGroup "Expr"
     , test "do"
         -- TODO: add more tests.
         [ "do (let x = 1 in x)" :~ do' [stmt $ let' [valBind "x" (int 1)] (var "x")]
-        ]
-    , test "tyApp"
-        [ "x @t" :~ var "x" `tyApp` var "t"
-        , "(f x) @t" :~ (var "f" @@ var "x") `tyApp` var "t"
-        , "f x @t" :~ var "f" @@ (var "x" `tyApp` var "t")
         ]
     ]
   where


### PR DESCRIPTION
The precedence with which GHC parses `@` in expressions changes
depending on whether `-XTypeApplications` is set.

In particular,
```
(var "f" @@ var "x") `tyApp` var "t"
```
should render to `"f x @t"`.