### PR TITLE
Fix pretty-printing of rational literals.

### DIFF
--- a/src/GHC/SourceGen/Expr/Internal.hs
+++ b/src/GHC/SourceGen/Expr/Internal.hs
@@ -7,13 +7,10 @@
 {-# LANGUAGE CPP #-}
 module GHC.SourceGen.Expr.Internal where
 
-#if MIN_VERSION_ghc(8,4,0)
-import BasicTypes (IntegralLit(..))
-#endif
 import HsExpr
-import HsLit
 import SrcLoc (Located, unLoc)
 
+import GHC.SourceGen.Lit.Internal
 import GHC.SourceGen.Syntax.Internal
 
 parenthesizeExprForApp, parenthesizeExprForOp
@@ -56,20 +53,3 @@ needsExprForApp e = case e of
     HsStatic{} -> True
     _ -> needsExprForOp e
 
-litNeedsParen :: HsLit' -> Bool
--- For now, ignoring cases that only arrive from internal compiler passes.
--- Furthermore, GHC parses primitive numbers like -3.0# without needing parentheses.
--- So we can uniformly ignore this step.
-litNeedsParen _ = False
-
-overLitNeedsParen :: HsOverLit' -> Bool
-overLitNeedsParen = needs . ol_val
-  where
-#if MIN_VERSION_ghc(8,4,0)
-    needs (HsIntegral x) = il_neg x
-#else
-    needs (HsIntegral _ x) = x < 0
-#endif
-    -- GHC shows fractional values with "%", so wrap them unconditionally.
-    needs HsFractional{} = True
-    needs _ = False

--- a/src/GHC/SourceGen/Lit.hs
+++ b/src/GHC/SourceGen/Lit.hs
@@ -19,7 +19,7 @@ module GHC.SourceGen.Lit
 
 import BasicTypes (FractionalLit(..))
 #if MIN_VERSION_ghc(8,4,0)
-import BasicTypes(IntegralLit(..))
+import BasicTypes(IntegralLit(..), SourceText(..))
 #endif
 import HsLit
 import HsExpr (noExpr, noSyntaxExpr, HsExpr(..))
@@ -63,7 +63,8 @@ frac :: HasLit e => Rational -> e
 frac x = overLit $ withPlaceHolder $ withPlaceHolder (noExt OverLit $ HsFractional il) noExpr
   where
 #if MIN_VERSION_ghc(8,4,0)
-    il = noSourceText FL (x < 0) x
+    il = FL (SourceText s) (x < 0) x
 #else
-    il = FL (show x) x
+    il = FL s x
 #endif
+    s = show (fromRational x :: Double)

--- a/src/GHC/SourceGen/Lit/Internal.hs
+++ b/src/GHC/SourceGen/Lit/Internal.hs
@@ -4,9 +4,33 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE CPP #-}
 module GHC.SourceGen.Lit.Internal where
 
-import BasicTypes (SourceText(NoSourceText))
+import BasicTypes (SourceText(NoSourceText), FractionalLit(..))
+#if MIN_VERSION_ghc(8,4,0)
+import BasicTypes (IntegralLit(..))
+#endif
+import HsLit
+import GHC.SourceGen.Syntax.Internal
 
 noSourceText :: (SourceText -> a) -> a
 noSourceText = ($ NoSourceText)
+
+litNeedsParen :: HsLit' -> Bool
+-- For now, ignoring cases that only arrive from internal compiler passes.
+-- Furthermore, GHC parses primitive numbers like -3.0# without needing parentheses.
+-- So we can uniformly ignore this step.
+litNeedsParen _ = False
+
+overLitNeedsParen :: HsOverLit' -> Bool
+overLitNeedsParen = needs . ol_val
+  where
+#if MIN_VERSION_ghc(8,4,0)
+    needs (HsIntegral x) = il_neg x
+    needs (HsFractional x) = fl_neg x
+#else
+    needs (HsIntegral _ x) = x < 0
+    needs (HsFractional x) = fl_value x < 0
+#endif
+    needs _ = False

--- a/src/GHC/SourceGen/Pat/Internal.hs
+++ b/src/GHC/SourceGen/Pat/Internal.hs
@@ -4,7 +4,7 @@ module GHC.SourceGen.Pat.Internal where
 import HsPat (Pat(..))
 import HsTypes (HsConDetails(..))
 
-import GHC.SourceGen.Expr.Internal (litNeedsParen, overLitNeedsParen)
+import GHC.SourceGen.Lit.Internal (litNeedsParen, overLitNeedsParen)
 import GHC.SourceGen.Syntax.Internal
 import SrcLoc (unLoc)
 

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -122,8 +122,8 @@ exprsTest dflags = testGroup "Expr"
             :~ var "A" @@ var "w" @@ (var "B" @@ var "x" @@ var "y") @@ var "Z"
         , "A 3" :~ var "A" @@ int 3
         , "A (-3)" :~ var "A" @@ int (-3)
-        , "A (3 % 1)" :~ var "A" @@ frac 3.0
-        , "A ((-3) % 1)" :~ var "A" @@ frac (-3.0)
+        , "A 3.0" :~ var "A" @@ frac 3.0
+        , "A (-3.0)" :~ var "A" @@ frac (-3.0)
         , "A 'x'" :~ var "A" @@ char 'x'
         , "A \"xyz\"" :~ var "A" @@ string "xyz"
         , "(\\ x -> x) (\\ x -> x)" :~
@@ -275,9 +275,8 @@ patsTest dflags = testGroup "Pats"
             :~ conP "A" [var "w", conP "B" [var "x", var "y"], conP "Z" []]
         , "A 3" :~ conP "A" [int 3]
         , "A (-3)" :~ conP "A" [int (-3)]
-        -- TODO(#33): this is incorrect:
-        -- , "A (3 % 1)" :~ conP "A" [frac 3.0]
-        -- , "A ((-3) % 1)" :~ conP "A" [frac (-3.0)]
+        , "A 3.0" :~ conP "A" [frac 3.0]
+        , "A (-3.0)" :~ conP "A" [frac (-3.0)]
         , "A 'x'" :~ conP "A" [char 'x']
         , "A \"xyz\"" :~ conP "A" [string "xyz"]
         , "A B {x = C}"


### PR DESCRIPTION
Print them in double syntax, just like they're parsed.
Fixes #33.