### PR TITLE
Make `tyPromotedVar` pretty-print as `'Abc` not `Abc`.

### DIFF
--- a/src/GHC/SourceGen/Type.hs
+++ b/src/GHC/SourceGen/Type.hs
@@ -4,7 +4,6 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE CPP #-}
 -- | This module provides combinators for constructing Haskell types.
 module GHC.SourceGen.Type
     ( HsType'

--- a/src/GHC/SourceGen/Type.hs
+++ b/src/GHC/SourceGen/Type.hs
@@ -4,6 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE CPP #-}
 -- | This module provides combinators for constructing Haskell types.
 module GHC.SourceGen.Type
     ( HsType'
@@ -28,7 +29,7 @@ import GHC.SourceGen.Type.Internal
 
 -- | A promoted name, for example from the @DataKinds@ extension.
 tyPromotedVar :: RdrNameStr -> HsType'
-tyPromotedVar = noExt HsTyVar notPromoted . typeRdrName
+tyPromotedVar = noExt HsTyVar promoted . typeRdrName
 
 stringTy :: String -> HsType'
 stringTy = noExt HsTyLit . noSourceText HsStrTy . fromString

--- a/tests/GhcVersion.hs
+++ b/tests/GhcVersion.hs
@@ -1,0 +1,16 @@
+-- A module for changing behavior based on the version of GHC.
+{-# LANGUAGE CPP #-}
+module GhcVersion where
+
+import Data.Version
+import Text.ParserCombinators.ReadP
+
+ghcVersion :: Version
+ghcVersion = case readP_to_S (parseVersion <* eof) VERSION_ghc of
+    [(v,"")] -> v
+    _ -> error $ "Unable to parse GHC version " ++ show VERSION_ghc
+
+ifGhc88 :: a -> a -> a
+ifGhc88 x y = if makeVersion [8,8] <= ghcVersion
+                then x
+                else y

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -11,6 +11,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import GHC.SourceGen
+import GhcVersion
 
 data TestCase a = String :~ a
 
@@ -97,6 +98,11 @@ typesTest dflags = testGroup "Type"
         , "[]" :~ listPromotedTy []
         , "[x]" :~ listPromotedTy [var "x"]
         , "[y, z]" :~ listPromotedTy [var "y", var "z"]
+        ]
+    , test "tyPromotedVar"
+        -- For some reason, older GHC pretty-printed an extra space.
+        [ ifGhc88 "'Abc" " 'Abc" :~ tyPromotedVar "Abc"
+        , ifGhc88 "T 'Abc" "T  'Abc" :~ var "T" @@ tyPromotedVar "Abc"
         ]
     ]
   where


### PR DESCRIPTION
Also make it possible for unit tests to change behavior based on the version of GHC.
