### PR TITLE
Add `occNameToStr` and `nameToStr` to convert from the GHC types.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for haskell-syntax
 
+## Unreleased
+- Add `occNameToStr` and `nameToStr` to convert from the GHC types.
+
 ## 0.2.0.1
 - Bump upper-bound to allow `QuickCheck-2.13`.
 

--- a/src/GHC/SourceGen/Name.hs
+++ b/src/GHC/SourceGen/Name.hs
@@ -20,6 +20,8 @@ module GHC.SourceGen.Name
     , OccNameStr
     , occNameStrToString
     , occNameStrNamespace
+    , occNameToStr
+    , nameToStr
       -- ModuleNameStr
     , ModuleNameStr(..)
     , moduleNameStrToString
@@ -28,6 +30,8 @@ module GHC.SourceGen.Name
 import FastString (unpackFS)
 import Module (moduleNameString)
 import GHC.SourceGen.Name.Internal
+import OccName (OccName, occNameFS, occNameSpace, isVarNameSpace)
+import Name (Name, nameOccName)
 
 unqual :: OccNameStr -> RdrNameStr
 unqual = UnqualStr
@@ -48,3 +52,18 @@ rdrNameStrToString :: RdrNameStr -> String
 rdrNameStrToString (UnqualStr o) = occNameStrToString o
 rdrNameStrToString (QualStr m o) =
     moduleNameStrToString m ++ '.' : occNameStrToString o
+
+-- | Converts a GHC 'OccName' to an 'OccNameStr'.  Ignores whether the input
+-- came from the namespace of types or of values.
+occNameToStr :: OccName -> OccNameStr
+occNameToStr o = OccNameStr n (occNameFS o)
+  where
+    n = if isVarNameSpace $ occNameSpace o
+            then Value
+            else Constructor
+
+-- | Converts from a GHC 'Name' to an 'OccNameStr'.  Ignores whether
+-- the input came from the namespace of types or of values, as well
+-- as any other information about where the name came from.
+nameToStr :: Name -> OccNameStr
+nameToStr = occNameToStr  . nameOccName

--- a/tests/name_test.hs
+++ b/tests/name_test.hs
@@ -3,6 +3,8 @@ module Main (main) where
 
 import GHC.SourceGen.Name
 
+import OccName
+
 import Data.List (intercalate)
 import Data.String (fromString)
 import Test.Tasty
@@ -41,6 +43,16 @@ testOccName = testGroup "OccName"
         occNameStrNamespace (fromString n) === Value
     , testProperty "punctuation" $ forAll genOp $ \n ->
         occNameStrNamespace (fromString n) === Value
+    , testGroup "occNameToStr"
+        [ testProperty "var" $ forAll genLowerName $ \n ->
+            occNameToStr (mkVarOcc n) === fromString n
+        , testProperty "data" $ forAll genUpperName $ \n ->
+            occNameToStr (mkDataOcc n) === fromString n
+        , testProperty "tyVar" $ forAll genLowerName $ \n ->
+            occNameToStr (mkTyVarOcc n) === fromString n
+        , testProperty "cls" $ forAll genUpperName $ \n ->
+            occNameToStr (mkClsOcc n) === fromString n
+        ]
     ]
 
 genUpperName, genLowerName, genOp :: Gen String


### PR DESCRIPTION
Previously it was cumbersome to create an `OccNameStr` from an
`OccName` or a `Name`.

Fixes #53.