### PR TITLE
Fix listPromotedTy on lists of one or zero elements.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Add `occNameToStr` and `nameToStr` to convert from the GHC types.
+- Make `listPromotedTy` emit the promoted form `'[..]`,
+  to distinguish from regular list types of zero or one elements.
 
 ## 0.2.0.1
 - Bump upper-bound to allow `QuickCheck-2.13`.

--- a/src/GHC/SourceGen/Type.hs
+++ b/src/GHC/SourceGen/Type.hs
@@ -40,7 +40,9 @@ listTy :: HsType' -> HsType'
 listTy = noExt HsListTy . builtLoc
 
 listPromotedTy :: [HsType'] -> HsType'
-listPromotedTy = withPlaceHolder (noExt HsExplicitListTy Promoted) . map builtLoc
+-- Lists of two or more elements don't need the explicit tick (`'`).
+-- But for consistency, just always add it.
+listPromotedTy = withPlaceHolder (noExt HsExplicitListTy promoted) . map builtLoc
 
 -- | A function type.
 --

--- a/src/GHC/SourceGen/Type.hs
+++ b/src/GHC/SourceGen/Type.hs
@@ -40,7 +40,7 @@ listTy :: HsType' -> HsType'
 listTy = noExt HsListTy . builtLoc
 
 listPromotedTy :: [HsType'] -> HsType'
-listPromotedTy = withPlaceHolder (noExt HsExplicitListTy notPromoted) . map builtLoc
+listPromotedTy = withPlaceHolder (noExt HsExplicitListTy Promoted) . map builtLoc
 
 -- | A function type.
 --

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -95,9 +95,9 @@ typesTest dflags = testGroup "Type"
         [ "()" :~ unit ]
    , test "list"
         [ "[x]" :~ listTy (var "x")
-        , "[]" :~ listPromotedTy []
-        , "[x]" :~ listPromotedTy [var "x"]
-        , "[y, z]" :~ listPromotedTy [var "y", var "z"]
+        , "'[]" :~ listPromotedTy []
+        , "'[x]" :~ listPromotedTy [var "x"]
+        , "'[y, z]" :~ listPromotedTy [var "y", var "z"]
         ]
     , test "tyPromotedVar"
         -- For some reason, older GHC pretty-printed an extra space.


### PR DESCRIPTION
We need the explicit `'` to distinguish from regular lists.
For simplicity, just use it for all type-level lists of
any length.