### PR TITLE
Type decl kind annotation

### DIFF
--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -276,11 +276,11 @@ newOrDataType newOrData name vars conDecls derivs
 
 -- | A newtype declaration.
 --
--- > newtype Const a b = Const a deriving Eq
+-- > newtype Const a b = Const a deriving Show
 -- > =====
 -- > newtype' "Const" ["a", "b"]
--- >    (conDecl "Const" [var "a"])
--- >    [var "Show"]
+-- >    (prefixCon "Const" [var "a"])
+-- >    [deriving' [var "Show"]]
 newtype' :: OccNameStr -> [OccNameStr] -> ConDecl' -> [HsDerivingClause'] -> HsDecl'
 newtype' name vars conD = newOrDataType NewType name (zip vars nothings) [conD]
 
@@ -290,7 +290,7 @@ newtype' name vars conD = newOrDataType NewType name (zip vars nothings) [conD]
 -- > =====
 -- > newtype' "Const" [("a", Nothing), ("b", Just (var "Type"))]
 -- >    (conDecl "Const" [var "a"])
--- >    [var "Show"]
+-- >    [deriving' [var "Show"]]
 newtype'' :: OccNameStr -> [(OccNameStr, Maybe HsType')] -> ConDecl' -> [HsDerivingClause'] -> HsDecl'
 newtype'' name kvars conD = newOrDataType NewType name kvars [conD]
 
@@ -300,10 +300,10 @@ newtype'' name kvars conD = newOrDataType NewType name kvars [conD]
 -- >    deriving Show
 -- > =====
 -- > data' "Either" ["a", "b"]
--- >   [ conDecl "Left" [var "a"]
--- >   , conDecl "Right" [var "b"]
+-- >   [ prefixCon "Left" [var "a"]
+-- >   , prefixCon "Right" [var "b"]
 -- >   ]
--- >   [var "Show"]
+-- >   [deriving' [var "Show"]]
 data' :: OccNameStr -> [OccNameStr] -> [ConDecl'] -> [HsDerivingClause'] -> HsDecl'
 data' n = newOrDataType DataType n . flip zip nothings
 
@@ -313,10 +313,10 @@ data' n = newOrDataType DataType n . flip zip nothings
 -- >    deriving Show
 -- > =====
 -- > data' "Either" [("a", Nothing), ("b", Just (var "Type"))]
--- >   [ conDecl "Left" [var "a"]
--- >   , conDecl "Right" [var "b"]
+-- >   [ prefixCon "Left" [var "a"]
+-- >   , prefixCon "Right" [var "b"]
 -- >   ]
--- >   [var "Show"]
+-- >   [deriving' [var "Show"]]
 data'' :: OccNameStr -> [(OccNameStr, Maybe HsType')] -> [ConDecl'] -> [HsDerivingClause'] -> HsDecl'
 data'' = newOrDataType DataType
 
@@ -325,7 +325,7 @@ data'' = newOrDataType DataType
 --
 -- > Foo a Int
 -- > =====
--- > conDecl "Foo" [field (var "a"), field (var "Int")]
+-- > prefixCon "Foo" [field (var "a"), field (var "Int")]
 prefixCon :: OccNameStr -> [Field] -> ConDecl'
 prefixCon name fields = renderCon98Decl name
     $ PrefixCon $ map renderField fields

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -150,7 +150,7 @@ class' context name vars decls
             , tcdFVs = PlaceHolder
 #endif
             , tcdLName = typeRdrName $ unqual name
-            , tcdTyVars = mkQTyVars vars
+            , tcdTyVars = mkQTyVars (zip vars nothings)
             , tcdFixity = Prefix
             , tcdFDs = [ builtLoc (map typeRdrName xs, map typeRdrName ys)
                        | ClassFunDep xs ys <- decls
@@ -250,7 +250,7 @@ tyFamInst name params ty = tyFamInstD
 type' :: OccNameStr -> [OccNameStr] -> HsType' -> HsDecl'
 type' name vars t =
     noExt TyClD $ withPlaceHolder $ noExt SynDecl (typeRdrName $ unqual name)
-        (mkQTyVars vars)
+        (mkQTyVars (zip vars nothings))
         Prefix
         (builtLoc t)
 
@@ -264,7 +264,7 @@ newOrDataType
 newOrDataType newOrData name vars conDecls derivs
     = noExt TyClD $ withPlaceHolder $ withPlaceHolder $
         noExt DataDecl (typeRdrName $ unqual name)
-            (mkQTyVars vars)
+            (mkQTyVars (zip vars nothings))
             Prefix
             $ noExt HsDataDefn newOrData
                 (builtLoc []) Nothing

--- a/src/GHC/SourceGen/Type/Internal.hs
+++ b/src/GHC/SourceGen/Type/Internal.hs
@@ -17,11 +17,11 @@ import GHC.SourceGen.Name.Internal
 mkQTyVars :: [(OccNameStr, Maybe HsType')] -> LHsQTyVars'
 mkQTyVars vars =  withPlaceHolder
                 $ noExt (withPlaceHolder HsQTvs)
-                $ map (builtLoc . noExt mkTyVar . bimap (typeRdrName . UnqualStr) (fmap builtLoc))
+                $ map (builtLoc . mkTyVar . bimap (typeRdrName . UnqualStr) (fmap builtLoc))
                     vars
 
-  where mkTyVar e (n, Nothing) = UserTyVar e n :: HsTyVarBndr'
-        mkTyVar e (n, Just k)  = KindedTyVar e n k
+  where mkTyVar (n, Nothing) = noExt UserTyVar n :: HsTyVarBndr'
+        mkTyVar (n, Just k)  = noExt KindedTyVar n k
 
 sigType :: HsType' -> LHsSigType'
 sigType = implicitBndrs . builtLoc

--- a/tests/pprint_test.hs
+++ b/tests/pprint_test.hs
@@ -279,6 +279,29 @@ declsTest dflags = testGroup "Decls"
         [ "pattern F a b = G b a"
             :~ patSynBind "F" ["a", "b"] $ conP "G" [bvar "b", bvar "a"]
         ]
+    , test "dataDecl"
+        [ "data Either a b\n  = Left a | Right b\n  deriving Show"
+            :~ data' "Either" ["a", "b"]
+               [ prefixCon "Left" [field $ var "a"]
+               , prefixCon "Right" [field $ var "b"]
+               ] $ [deriving' [var "Show"]]
+        , "data Either a (b :: Type)\n  = Left a | Right b\n  deriving Show"
+            :~ data'' "Either" [("a", Nothing), ("b", Just (var "Type"))]
+               [ prefixCon "Left" [field $ var "a"]
+               , prefixCon "Right" [field $ var "b"]
+               ] $ [deriving' [var "Show"]]
+        ]
+    , test "newtypeDecl"
+        [ "newtype Const a b\n  = Const a\n  deriving Show"
+            :~ newtype' "Const" ["a", "b"]
+               (prefixCon "Const" [field $ var "a"])
+               $ [deriving' [var "Show"]]
+        , "newtype Const a (b :: Type)\n  = Const a\n  deriving Show"
+            :~ newtype'' "Const" [("a", Nothing), ("b", Just (var "Type"))]
+               (prefixCon "Const" [field $ var "a"])
+               [deriving' [var "Show"]]
+        ]
+        
     ]
   where
     test = testDecls dflags


### PR DESCRIPTION
Optional kind annotations for data / newtype declarations. Can be extended for class and instance decls.