### PR TITLE
Remove support for ghc-8.2.*.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,6 @@
 version: 2
 
 jobs:
-  build-11.22:
-    docker:
-    - image: circleci/rust:1.36-stretch
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-            - stack-cache-v2-11.22-{{ arch }}-{{ .Branch }}
-            - stack-cache-v2-11.22-{{ arch }}-master
-    - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-11.22
-    - save_cache:
-            key: stack-cache-v2-11.22-{{ arch }}-{{ .Branch }}-{{ epoch }}
-            paths:
-                - ~/.stack
-                - .stack-work
   build-12.8:
     docker:
     - image: circleci/rust:1.36-stretch
@@ -77,13 +61,11 @@ workflows:
   version: 2
   build-and-test:
       jobs:
-        - build-11.22
         - build-12.8
         - build-13.23
         - build-ghc-8.8
         - build-success:
             requires:
-            - build-11.22
             - build-12.8
             - build-13.23
             - build-ghc-8.8

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 # Changelog for haskell-syntax
 
+
 # 0.4.0.0
 
 ## Breaking Changes
@@ -7,6 +8,7 @@
   type parameters as `HsTyVarBndr'` rather than `OccNameStr`.
   To construct a `HsTyVarBndr'`, use either `bvar` or `kindedVar`.
   Affects: `class'`, `type'`, `newtype'`, and `data'`.
+- Remove support for ghc-8.2.*.
 
 ## Other Changes
 - Add `kindedVar`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,5 @@
 # Changelog for haskell-syntax
 
-
 # 0.4.0.0
 
 ## Breaking Changes

--- a/ghc-show-ast/Main.hs
+++ b/ghc-show-ast/Main.hs
@@ -52,11 +52,7 @@ main = do
     result <- parseModule f
     print $ gPrint result
 
-#if MIN_VERSION_ghc(8,4,0)
 parseModule :: FilePath -> IO (GHC.HsModule GHC.GhcPs)
-#else
-parseModule :: FilePath -> IO (GHC.HsModule GHC.RdrName)
-#endif
 parseModule f = GHC.runGhc (Just libdir) $ do
     dflags <- GHC.getDynFlags
     contents <- GHC.liftIO $ GHC.stringToStringBuffer <$> readFile f
@@ -66,9 +62,7 @@ parseModule f = GHC.runGhc (Just libdir) $ do
     case GHC.unP Parser.parseModule state of
         GHC.POk _state m -> return $ GHC.unLoc m
         GHC.PFailed
-#if MIN_VERSION_ghc(8,4,0)
             _message
-#endif
             loc docs ->
             error $ GHC.showPpr dflags loc ++ GHC.showSDoc dflags docs
 

--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ description: |
 
 dependencies:
 - base >= 4.7 && < 5
-- ghc >= 8.2 && < 8.9
+- ghc >= 8.4 && < 8.9
 
 default-extensions:
 - DataKinds

--- a/src/GHC/SourceGen/Binds/Internal.hs
+++ b/src/GHC/SourceGen/Binds/Internal.hs
@@ -88,11 +88,6 @@ matchGroup context matches =
     mkMatch :: RawMatch -> Match' (Located HsExpr')
     mkMatch r = noExt Match context
                     (map builtPat $ map parenthesize $ rawMatchPats r)
-#if !MIN_VERSION_ghc(8,4,0)
-                    -- The GHC docs say: "A type signature for the result of the match."
-                    -- The parsing step produces 'Nothing' for this field.
-                    Nothing
-#endif
                     (mkGRHSs $ rawMatchGRHSs r)
 
 mkGRHSs :: RawGRHSs -> GRHSs' (Located HsExpr')

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -222,7 +222,6 @@ instance HasTyFamInst RawInstDecl where
 -- > tyFamInst "Elt" [var "String"] (var "Char")
 tyFamInst :: HasTyFamInst t => RdrNameStr -> [HsType'] -> HsType' -> t
 tyFamInst name params ty = tyFamInstD
-#if MIN_VERSION_ghc(8,4,0)
         $ TyFamInstDecl
         $ implicitBndrs
         $ noExt FamEqn (typeRdrName name)
@@ -234,13 +233,6 @@ tyFamInst name params ty = tyFamInstD
 #endif
             Prefix
             (builtLoc ty)
-#else
-        $ withPlaceHolder $ TyFamInstDecl
-        $ builtLoc $ TyFamEqn (typeRdrName name)
-                        (implicitBndrs $ map builtLoc params)
-                        Prefix
-                        (builtLoc ty)
-#endif
 
 -- | Declares a type synonym.
 --
@@ -441,12 +433,7 @@ patSynSig n = patSynSigs [n]
 patSynBind :: OccNameStr -> [OccNameStr] -> Pat' -> HsDecl'
 patSynBind n ns p = bindB $ noExt PatSynBind
                     $ withPlaceHolder (noExt PSB (valueRdrName $ unqual n))
-#if MIN_VERSION_ghc(8,4,0)
-                        (PrefixCon
-#else
-                        (PrefixPatSyn
-#endif
-                            (map (valueRdrName . unqual) ns))
+                        (PrefixCon (map (valueRdrName . unqual) ns))
                         (builtPat p)
                         ImplicitBidirectional
 

--- a/src/GHC/SourceGen/Lit.hs
+++ b/src/GHC/SourceGen/Lit.hs
@@ -4,7 +4,6 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE CPP #-}
 -- | This module provides combinators for constructing Haskell literals,
 -- which may be used in either patterns or expressions.
 module GHC.SourceGen.Lit
@@ -18,9 +17,7 @@ module GHC.SourceGen.Lit
     ) where
 
 import BasicTypes (FractionalLit(..))
-#if MIN_VERSION_ghc(8,4,0)
 import BasicTypes(IntegralLit(..), SourceText(..))
-#endif
 import HsLit
 import HsExpr (noExpr, noSyntaxExpr, HsExpr(..))
 import HsPat (Pat(..))
@@ -52,19 +49,11 @@ string = lit . noSourceText HsString . fsLit
 int :: HasLit e => Integer -> e
 int n = overLit $ withPlaceHolder $ withPlaceHolder (noExt OverLit il) noExpr
   where
-#if MIN_VERSION_ghc(8,4,0)
     il = HsIntegral $ noSourceText IL (n < 0) n
-#else
-    il = noSourceText HsIntegral n
-#endif
 
 -- | Note: this is an *overloaded* rational, e.g., a decimal number.
 frac :: HasLit e => Rational -> e
 frac x = overLit $ withPlaceHolder $ withPlaceHolder (noExt OverLit $ HsFractional il) noExpr
   where
-#if MIN_VERSION_ghc(8,4,0)
     il = FL (SourceText s) (x < 0) x
-#else
-    il = FL s x
-#endif
     s = show (fromRational x :: Double)

--- a/src/GHC/SourceGen/Lit/Internal.hs
+++ b/src/GHC/SourceGen/Lit/Internal.hs
@@ -4,13 +4,10 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE CPP #-}
 module GHC.SourceGen.Lit.Internal where
 
 import BasicTypes (SourceText(NoSourceText), FractionalLit(..))
-#if MIN_VERSION_ghc(8,4,0)
 import BasicTypes (IntegralLit(..))
-#endif
 import HsLit
 import GHC.SourceGen.Syntax.Internal
 
@@ -26,11 +23,6 @@ litNeedsParen _ = False
 overLitNeedsParen :: HsOverLit' -> Bool
 overLitNeedsParen = needs . ol_val
   where
-#if MIN_VERSION_ghc(8,4,0)
     needs (HsIntegral x) = il_neg x
     needs (HsFractional x) = fl_neg x
-#else
-    needs (HsIntegral _ x) = x < 0
-    needs (HsFractional x) = fl_value x < 0
-#endif
     needs _ = False

--- a/src/GHC/SourceGen/Syntax/Internal.hs
+++ b/src/GHC/SourceGen/Syntax/Internal.hs
@@ -63,9 +63,7 @@ import HsExtension (NoExt(NoExt))
 import PlaceHolder(PlaceHolder(..))
 #endif
 
-#if MIN_VERSION_ghc(8,4,0)
 import HsExtension (GhcPs)
-#endif
 
 #if MIN_VERSION_ghc(8,6,0)
 noExt :: (NoExt -> a) -> a
@@ -134,11 +132,7 @@ notPromoted = NotPromoted
 -- * 'GHC.SourceGen.Overloaded.Par'
 -- * 'GHC.SourceGen.Overloaded.App'
 -- * 'GHC.SourceGen.Overloaded.HasTuple'
-#if MIN_VERSION_ghc(8,4,0)
 type HsType' = HsType GhcPs
-#else
-type HsType' = HsType RdrName
-#endif
 
 -- | A Haskell pattern, as it is represented after the parsing step.
 --
@@ -149,11 +143,7 @@ type HsType' = HsType RdrName
 -- * 'GHC.SourceGen.Overloaded.HasTuple'
 -- * 'GHC.SourceGen.Overloaded.HasList'
 -- * 'GHC.SourceGen.Lit.HasLit'
-#if MIN_VERSION_ghc(8,4,0)
 type Pat' = Pat GhcPs
-#else
-type Pat' = Pat RdrName
-#endif
 
 -- | A Haskell expression, as it is represented after the parsing step.
 --
@@ -166,11 +156,7 @@ type Pat' = Pat RdrName
 -- * 'GHC.SourceGen.Overloaded.HasTuple'
 -- * 'GHC.SourceGen.Overloaded.HasList'
 -- * 'GHC.SourceGen.Lit.HasLit'
-#if MIN_VERSION_ghc(8,4,0)
 type HsExpr' = HsExpr GhcPs
-#else
-type HsExpr' = HsExpr RdrName
-#endif
 
 -- | A Haskell declaration, as it is represented after the parsing step.
 --
@@ -178,11 +164,7 @@ type HsExpr' = HsExpr RdrName
 --
 -- * 'GHC.SourceGen.Binds.HasValBind'
 -- * 'GHC.SourceGen.Binds.HasPatBind'
-#if MIN_VERSION_ghc(8,4,0)
 type HsDecl' = HsDecl GhcPs
-#else
-type HsDecl' = HsDecl RdrName
-#endif
 
 -- | An imported or exported entity, as it is represented after the parsing step.
 --
@@ -190,11 +172,7 @@ type HsDecl' = HsDecl RdrName
 --
 -- * 'GHC.SourceGen.Overloaded.BVar'
 -- * 'GHC.SourceGen.Overloaded.Var'
-#if MIN_VERSION_ghc(8,4,0)
 type IE' = IE GhcPs
-#else
-type IE' = IE RdrName
-#endif
 
 
 -- | A type variable binding, as it is represented after the parsing step.
@@ -205,13 +183,8 @@ type IE' = IE RdrName
 -- Instances:
 --
 -- * 'GHC.SourceGen.Overloaded.BVar'
-#if MIN_VERSION_ghc(8,4,0)
 type HsTyVarBndr' = HsTyVarBndr GhcPs
-#else
-type HsTyVarBndr' = HsTyVarBndr RdrName
-#endif
 
-#if MIN_VERSION_ghc(8,4,0)
 type HsLit' = HsLit GhcPs
 type HsModule' = HsModule GhcPs
 type HsBind' = HsBind GhcPs
@@ -238,36 +211,6 @@ type LHsRecUpdField' = LHsRecUpdField GhcPs
 type LPat' = LPat GhcPs
 type HsImplicitBndrs' = HsImplicitBndrs GhcPs
 type TyFamInstDecl' = TyFamInstDecl GhcPs
-
-#else
-type HsLit' = HsLit
-type HsModule' = HsModule RdrName
-type HsBind' = HsBind RdrName
-type HsLocalBinds' = HsLocalBinds RdrName
-type HsValBinds' = HsValBinds RdrName
-type Sig' = Sig RdrName
-type HsMatchContext' = HsMatchContext RdrName
-type Match' = Match RdrName
-type MatchGroup' = MatchGroup RdrName
-type GRHS' = GRHS RdrName
-type GRHSs' = GRHSs RdrName
-type Stmt' = Stmt RdrName (Located HsExpr')
-type HsOverLit' = HsOverLit RdrName
-type LHsQTyVars' = LHsQTyVars RdrName
-type ConDecl' = ConDecl RdrName
-type HsConDeclDetails' = HsConDeclDetails RdrName
-type LHsSigType' = LHsSigType RdrName
-type ImportDecl' = ImportDecl RdrName
-type LHsSigWcType' = LHsSigWcType RdrName
-type LHsWcType' = LHsWcType RdrName
-type HsDerivingClause' = HsDerivingClause RdrName
-type LHsRecField' arg = LHsRecField RdrName arg
-type LHsRecUpdField' = LHsRecUpdField RdrName
-type LPat' = LPat RdrName
-type HsImplicitBndrs' = HsImplicitBndrs RdrName
-type TyFamInstDecl' = TyFamInstDecl RdrName
-
-#endif
 
 #if MIN_VERSION_ghc(8,6,0)
 type DerivStrategy' = DerivStrategy GhcPs


### PR DESCRIPTION
ghc-8.4 was released more than 2 years ago. This balances
some of the noise from the upcoming support for `ghc-8.10`.