### PR TITLE
Allow tasty 1.3 and QuickCheck 2.14

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -70,7 +70,7 @@ tests:
     dependencies:
     - ghc-source-gen
     - ghc-paths == 0.1.*
-    - tasty >= 1.0 && < 1.3
+    - tasty >= 1.0 && < 1.4
     - tasty-hunit == 0.10.*
 
   # TODO: Fill out this test, and use it to replace pprint_examples.
@@ -80,7 +80,7 @@ tests:
     dependencies:
     - ghc-source-gen
     - ghc-paths == 0.1.*
-    - tasty >= 1.0 && < 1.3
+    - tasty >= 1.0 && < 1.4
     - tasty-hunit == 0.10.*
 
   name_test:
@@ -88,7 +88,7 @@ tests:
     source-dirs: tests
     dependencies:
     - ghc-source-gen
-    - QuickCheck >= 2.10 && < 2.14
-    - tasty >= 1.0 && < 1.3
+    - QuickCheck >= 2.10 && < 2.15
+    - tasty >= 1.0 && < 1.4
     - tasty-hunit == 0.10.*
     - tasty-quickcheck >= 0.9 && < 0.11


### PR DESCRIPTION
All tests pass here with tasty 1.3.1 and QuickCheck 2.14.2.