### PR TITLE
CI: use correct resolver version for ghc-8.10 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
             - stack-cache-v2-ghc-8.10-{{ arch }}-{{ .Branch }}
             - stack-cache-v2-ghc-8.10-{{ arch }}-master
     - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-15.13
+    - run: stack test --no-terminal --resolver=lts-18.5
     - save_cache:
             key: stack-cache-v2-ghc-8.10-{{ arch }}-{{ .Branch }}-{{ epoch }}
             paths:

--- a/package.yaml
+++ b/package.yaml
@@ -70,7 +70,7 @@ tests:
     dependencies:
     - ghc-source-gen
     - ghc-paths == 0.1.*
-    - tasty >= 1.0 && < 1.4
+    - tasty >= 1.0 && < 1.5
     - tasty-hunit == 0.10.*
 
   # TODO: Fill out this test, and use it to replace pprint_examples.
@@ -80,7 +80,7 @@ tests:
     dependencies:
     - ghc-source-gen
     - ghc-paths == 0.1.*
-    - tasty >= 1.0 && < 1.4
+    - tasty >= 1.0 && < 1.5
     - tasty-hunit == 0.10.*
 
   name_test:
@@ -89,6 +89,6 @@ tests:
     dependencies:
     - ghc-source-gen
     - QuickCheck >= 2.10 && < 2.15
-    - tasty >= 1.0 && < 1.4
+    - tasty >= 1.0 && < 1.5
     - tasty-hunit == 0.10.*
     - tasty-quickcheck >= 0.9 && < 0.11


### PR DESCRIPTION
Based on https://www.stackage.org/lts-18.5