### PR TITLE
Commit cabal file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,89 +1,41 @@
-version: 2
+version: 2.1
 
 jobs:
-  build-12.8:
-    docker:
-    - image: circleci/rust:1.36-stretch
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-            - stack-cache-v2-12.8-{{ arch }}-{{ .Branch }}
-            - stack-cache-v2-12.8-{{ arch }}-master
-    - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-12.8
-    - save_cache:
-            key: stack-cache-v2-12.8-{{ arch }}-{{ .Branch }}-{{ epoch }}
-            paths:
-                - ~/.stack
-                - .stack-work
-  build-13.23:
-    docker:
-    - image: circleci/rust:1.36-stretch
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-            - stack-cache-v2-13.23-{{ arch }}-{{ .Branch }}
-            - stack-cache-v2-13.23-{{ arch }}-master
-    - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-13.23
-    - save_cache:
-            key: stack-cache-v2-13.23-{{ arch }}-{{ .Branch }}-{{ epoch }}
-            paths:
-                - ~/.stack
-                - .stack-work
+  build:
+    parameters:
+      resolver:
+        type: string
+        default: ''
+      stack_yaml:
+        type: string
+        default: stack.yaml
 
-  build-15.13:
     docker:
     - image: circleci/rust:1.36-stretch
+    environment:
+      STACK_YAML: << parameters.stack_yaml >>
+      RESOLVER: << parameters.resolver >>
     steps:
     - checkout
     - restore_cache:
         keys:
-            - stack-cache-v2-ghc-15.13-{{ arch }}-{{ .Branch }}
-            - stack-cache-v2-ghc-15.13-{{ arch }}-master
+          - stack-cache-v2-<< parameters.resolver >>-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          - stack-cache-v2-<< parameters.resolver >>-{{ arch }}-{{ .Branch }}
+          - stack-cache-v2-<< parameters.resolver >>-{{ arch }}-master
     - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-15.13
+    - run:
+        name: Build + test
+        command: |
+          STACK_FLAGS=(--no-terminal)
+          if [[ -n "${RESOLVER}" ]]; then
+            STACK_FLAGS+=(--resolver="${RESOLVER}")
+          fi
+          stack test "${STACK_FLAGS[@]}"
     - save_cache:
-            key: stack-cache-v2-ghc-15.13-{{ arch }}-{{ .Branch }}-{{ epoch }}
-            paths:
-                - ~/.stack
-                - .stack-work
-
-  build-ghc-8.10:
-    docker:
-    - image: circleci/rust:1.36-stretch
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-            - stack-cache-v2-ghc-8.10-{{ arch }}-{{ .Branch }}
-            - stack-cache-v2-ghc-8.10-{{ arch }}-master
-    - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --resolver=lts-18.5
-    - save_cache:
-            key: stack-cache-v2-ghc-8.10-{{ arch }}-{{ .Branch }}-{{ epoch }}
-            paths:
-                - ~/.stack
-                - .stack-work
-
-  build-ghc-9.0:
-    docker:
-    - image: circleci/rust:1.36-stretch
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-            - stack-cache-v2-ghc-8.10-{{ arch }}-{{ .Branch }}
-            - stack-cache-v2-ghc-8.10-{{ arch }}-master
-    - run: .circleci/install-stack.sh
-    - run: stack test --no-terminal --stack-yaml stack-9.0.yaml
-    - save_cache:
-            key: stack-cache-v2-ghc-9.0-{{ arch }}-{{ .Branch }}-{{ epoch }}
-            paths:
-                - ~/.stack
-                - .stack-work
+        key: stack-cache-v2-<< parameters.resolver >>-{{ arch }}-{{ .Branch }}-{{ epoch }}
+        paths:
+          - ~/.stack
+          - .stack-work
 
   build-success:
     docker:
@@ -94,16 +46,19 @@ jobs:
 workflows:
   version: 2
   build-and-test:
-      jobs:
-        - build-12.8
-        - build-13.23
-        - build-15.13
-        - build-ghc-8.10
+    jobs:
+    - build:
+        matrix:
+          parameters:
+            resolver:
+            - lts-12.8
+            - lts-13.23
+            - lts-15.13
+            - lts-18.5
+    - build:
+        name: build-ghc-9.0
+        stack_yaml: stack-9.0.yaml
+    - build-success:
+        requires:
+        - build
         - build-ghc-9.0
-        - build-success:
-            requires:
-            - build-12.8
-            - build-13.23
-            - build-15.13
-            - build-ghc-8.10
-            - build-ghc-9.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
             STACK_FLAGS+=(--resolver="${RESOLVER}")
           fi
           stack test "${STACK_FLAGS[@]}"
+    - run:
+        name: Check Cabal file up to date
+        command: git diff --exit-code *.cabal
     - save_cache:
         key: stack-cache-v2-<< parameters.resolver >>-{{ arch }}-{{ .Branch }}-{{ epoch }}
         paths:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .stack-work/
 dist/
 # Generated automatically by hpack:
-*.cabal
 *.yaml.lock

--- a/ghc-show-ast/ghc-show-ast.cabal
+++ b/ghc-show-ast/ghc-show-ast.cabal
@@ -1,0 +1,20 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           ghc-show-ast
+version:        0.0.0
+build-type:     Simple
+
+executable ghc-show-ast
+  main-is: Main.hs
+  other-modules:
+      Paths_ghc_show_ast
+  build-depends:
+      base
+    , ghc
+    , ghc-paths
+    , pretty
+  default-language: Haskell2010

--- a/ghc-source-gen.cabal
+++ b/ghc-source-gen.cabal
@@ -1,0 +1,172 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           ghc-source-gen
+version:        0.4.1.0
+synopsis:       Constructs Haskell syntax trees for the GHC API.
+description:    @ghc-source-gen@ is a library for generating Haskell source code.
+                It uses the <https://hackage.haskell.org/package/ghc ghc> library
+                to support recent language extensions, and provides a simple, consistent
+                interface across several major versions of GHC.
+                .
+                To get started, take a look at the "GHC.SourceGen" module.
+                .
+                For more information, please see the <https://github.com/google/ghc-source-gen README>.
+category:       Development
+homepage:       https://github.com/google/ghc-source-gen#readme
+bug-reports:    https://github.com/google/ghc-source-gen/issues
+author:         Judah Jacobson
+maintainer:     judahjacobson@google.com
+copyright:      Google LLC
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/google/ghc-source-gen
+
+library
+  exposed-modules:
+      GHC.SourceGen
+      GHC.SourceGen.Binds
+      GHC.SourceGen.Decl
+      GHC.SourceGen.Expr
+      GHC.SourceGen.Lit
+      GHC.SourceGen.Module
+      GHC.SourceGen.Name
+      GHC.SourceGen.Overloaded
+      GHC.SourceGen.Pat
+      GHC.SourceGen.Pat.Internal
+      GHC.SourceGen.Pretty
+      GHC.SourceGen.Type
+  other-modules:
+      GHC.SourceGen.Binds.Internal
+      GHC.SourceGen.Expr.Internal
+      GHC.SourceGen.Lit.Internal
+      GHC.SourceGen.Name.Internal
+      GHC.SourceGen.Syntax.Internal
+      GHC.SourceGen.Type.Internal
+  hs-source-dirs:
+      src
+  default-extensions:
+      DataKinds
+      FlexibleInstances
+      TypeSynonymInstances
+  build-depends:
+      base >=4.7 && <5
+    , ghc >=8.4 && <9.2
+  if impl(ghc<8.10)
+    other-modules:
+        GHC.Hs
+        GHC.Hs.Binds
+        GHC.Hs.Decls
+        GHC.Hs.Expr
+        GHC.Hs.Extension
+        GHC.Hs.ImpExp
+        GHC.Hs.Lit
+        GHC.Hs.Pat
+        GHC.Hs.Type
+        GHC.Hs.Utils
+        GHC.Driver.Monad
+        GHC.Driver.Session
+        GHC.Utils.Outputable
+        GHC.Types.Basic
+        GHC.Plugins
+        GHC.Tc.Types.Evidence
+    hs-source-dirs:
+        compat
+  if impl(ghc>=8.10) && impl(ghc<9.0)
+    other-modules:
+        GHC.Hs.Type
+        GHC.Driver.Monad
+        GHC.Driver.Session
+        GHC.Utils.Outputable
+        GHC.Types.Basic
+        GHC.Plugins
+        GHC.Tc.Types.Evidence
+    hs-source-dirs:
+        compat-8.10
+  default-language: Haskell2010
+
+test-suite name_test
+  type: exitcode-stdio-1.0
+  main-is: name_test.hs
+  other-modules:
+      GhcVersion
+      Paths_ghc_source_gen
+  hs-source-dirs:
+      tests
+  default-extensions:
+      DataKinds
+      FlexibleInstances
+      TypeSynonymInstances
+  build-depends:
+      QuickCheck >=2.10 && <2.15
+    , base >=4.7 && <5
+    , ghc >=8.4 && <9.2
+    , ghc-source-gen
+    , tasty >=1.0 && <1.5
+    , tasty-hunit ==0.10.*
+    , tasty-quickcheck >=0.9 && <0.11
+  default-language: Haskell2010
+
+test-suite pprint_examples
+  type: exitcode-stdio-1.0
+  main-is: pprint_examples.hs
+  other-modules:
+      GhcVersion
+      Paths_ghc_source_gen
+  hs-source-dirs:
+      tests
+  default-extensions:
+      DataKinds
+      FlexibleInstances
+      TypeSynonymInstances
+  build-depends:
+      base >=4.7 && <5
+    , ghc >=8.4 && <9.2
+    , ghc-paths ==0.1.*
+    , ghc-source-gen
+    , tasty >=1.0 && <1.5
+    , tasty-hunit ==0.10.*
+  if impl(ghc<9.0)
+    other-modules:
+        GHC.Utils.Outputable
+    hs-source-dirs:
+        compat
+  default-language: Haskell2010
+
+test-suite pprint_test
+  type: exitcode-stdio-1.0
+  main-is: pprint_test.hs
+  other-modules:
+      GhcVersion
+      Paths_ghc_source_gen
+  hs-source-dirs:
+      tests
+  default-extensions:
+      DataKinds
+      FlexibleInstances
+      TypeSynonymInstances
+  build-depends:
+      base >=4.7 && <5
+    , ghc >=8.4 && <9.2
+    , ghc-paths ==0.1.*
+    , ghc-source-gen
+    , tasty >=1.0 && <1.5
+    , tasty-hunit ==0.10.*
+  if impl(ghc<9.0)
+    other-modules:
+        GHC.Driver.Monad
+        GHC.Driver.Session
+        GHC.Utils.Outputable
+    hs-source-dirs:
+        compat
+  default-language: Haskell2010


### PR DESCRIPTION
This allows people to specify `ghc-source-gen` as an extra-dep via git commit:

```yaml
# stack.yaml
extra-deps:
  - github: google/ghc-source-gen
    commit: 1234567890abcdef
```

For example, it's useful now, to be able to use the `HEAD` of `ghc-source-gen` without waiting for a Hackage release. But this only works if the repo has `.cabal` committed. (more info: https://www.fpcomplete.com/blog/storing-generated-cabal-files/)

Also added a check in CI to ensure that the cabal file has been updated. I also simplified the CI config with Circle CI's new parameterized jobs syntax, which also fixes some bugs (e.g. the `build-ghc-9.0` job specified the wrong cache keys when restoring, so it was previously always a cache miss)