### PR TITLE
Bump version for a ghc-9.2-compatible release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for haskell-syntax
 
+# 0.4.3.0
+- Support GHC 9.2.
+
 # 0.4.2.0
 - Support GHC 9.
 

--- a/ghc-source-gen.cabal
+++ b/ghc-source-gen.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           ghc-source-gen
-version:        0.4.2.0
+version:        0.4.3.0
 synopsis:       Constructs Haskell syntax trees for the GHC API.
 description:    @ghc-source-gen@ is a library for generating Haskell source code.
                 It uses the <https://hackage.haskell.org/package/ghc ghc> library

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@
 # https://developers.google.com/open-source/licenses/bsd
 
 name:                ghc-source-gen
-version:             0.4.2.0
+version:             0.4.3.0
 github:              "google/ghc-source-gen"
 license:             BSD3
 author:              "Judah Jacobson"


### PR DESCRIPTION
IIUC, this package is compatible with ghc-9.2 as per #92, and merely lacks a hackage release to that effect; @jinwoo, may I ask you to do the honors?