### PR TITLE
Make Cabal 3.7 happy

### DIFF
--- a/ghc-source-gen.cabal
+++ b/ghc-source-gen.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -72,17 +72,11 @@ library
         GHC.Hs.ImpExp
         GHC.Hs.Lit
         GHC.Hs.Pat
-        GHC.Hs.Type
         GHC.Hs.Utils
-        GHC.Driver.Monad
-        GHC.Driver.Session
-        GHC.Utils.Outputable
-        GHC.Types.Basic
-        GHC.Plugins
-        GHC.Tc.Types.Evidence
     hs-source-dirs:
         compat
-  if impl(ghc>=8.10) && impl(ghc<9.0)
+  default-language: Haskell2010
+  if impl(ghc<9.0)
     other-modules:
         GHC.Hs.Type
         GHC.Driver.Monad
@@ -91,9 +85,9 @@ library
         GHC.Types.Basic
         GHC.Plugins
         GHC.Tc.Types.Evidence
+  if impl(ghc>=8.10) && impl(ghc<9.0)
     hs-source-dirs:
         compat-8.10
-  default-language: Haskell2010
 
 test-suite name_test
   type: exitcode-stdio-1.0

--- a/package.yaml
+++ b/package.yaml
@@ -52,26 +52,22 @@ library:
     - GHC.Hs.ImpExp
     - GHC.Hs.Lit
     - GHC.Hs.Pat
-    - GHC.Hs.Type
     - GHC.Hs.Utils
-    - GHC.Driver.Monad
-    - GHC.Driver.Session
-    - GHC.Utils.Outputable
-    - GHC.Types.Basic
-    - GHC.Plugins
-    - GHC.Tc.Types.Evidence
 
-  - condition: impl(ghc>=8.10) && impl(ghc<9.0)
-    source-dirs: compat-8.10
-    other-modules:
-    - GHC.Hs.Type
-    - GHC.Driver.Monad
-    - GHC.Driver.Session
-    - GHC.Utils.Outputable
-    - GHC.Types.Basic
-    - GHC.Plugins
-    - GHC.Tc.Types.Evidence
-    
+  verbatim: |
+    if impl(ghc<9.0)
+      other-modules:
+          GHC.Hs.Type
+          GHC.Driver.Monad
+          GHC.Driver.Session
+          GHC.Utils.Outputable
+          GHC.Types.Basic
+          GHC.Plugins
+          GHC.Tc.Types.Evidence
+    if impl(ghc>=8.10) && impl(ghc<9.0)
+      hs-source-dirs:
+          compat-8.10
+
   source-dirs: src
   other-modules:
   - GHC.SourceGen.Binds.Internal


### PR DESCRIPTION
Cabal 3.7 (built from HEAD) has a stricter validation for conditionals and complains about duplicate modules:
```
$ cabal build
Resolving dependencies...
Build profile: -w ghc-8.10.6 -O1
In order, the following will be built (use -v for more details):
 - ghc-source-gen-0.4.3.0 (lib) (first run)
Configuring library for ghc-source-gen-0.4.3.0..
Error: cabal: Duplicate modules in library: GHC.Driver.Monad,
GHC.Driver.Session, GHC.Hs.Type, GHC.Plugins, GHC.Tc.Types.Evidence,
GHC.Types.Basic, GHC.Utils.Outputable
```

It seems this stricter validation contradicts `hpack`'s efforts to normalise conditional blocks, so I had to use `verbatim`.

CC @sol @gbaz @jinwoo 