### PR TITLE
Support GHC 9.6

### DIFF
--- a/ghc-source-gen.cabal
+++ b/ghc-source-gen.cabal
@@ -61,7 +61,7 @@ library
       TypeSynonymInstances
   build-depends:
       base >=4.7 && <5
-    , ghc >=8.4 && <9.5
+    , ghc >=8.4 && <9.7
   if impl(ghc<8.10)
     other-modules:
         GHC.Hs
@@ -104,7 +104,7 @@ test-suite name_test
   build-depends:
       QuickCheck >=2.10 && <2.15
     , base >=4.7 && <5
-    , ghc >=8.4 && <9.5
+    , ghc >=8.4 && <9.7
     , ghc-source-gen
     , tasty >=1.0 && <1.5
     , tasty-hunit ==0.10.*
@@ -125,7 +125,7 @@ test-suite pprint_examples
       TypeSynonymInstances
   build-depends:
       base >=4.7 && <5
-    , ghc >=8.4 && <9.5
+    , ghc >=8.4 && <9.7
     , ghc-paths ==0.1.*
     , ghc-source-gen
     , tasty >=1.0 && <1.5
@@ -151,7 +151,7 @@ test-suite pprint_test
       TypeSynonymInstances
   build-depends:
       base >=4.7 && <5
-    , ghc >=8.4 && <9.5
+    , ghc >=8.4 && <9.7
     , ghc-paths ==0.1.*
     , ghc-source-gen
     , tasty >=1.0 && <1.5

--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ description: |
 
 dependencies:
 - base >= 4.7 && < 5
-- ghc >= 8.4 && < 9.5
+- ghc >= 8.4 && < 9.7
 
 default-extensions:
 - DataKinds

--- a/src/GHC/SourceGen/Binds.hs
+++ b/src/GHC/SourceGen/Binds.hs
@@ -101,7 +101,7 @@ typeSig n = typeSigs [n]
 funBindsWithFixity :: HasValBind t => Maybe LexicalFixity -> OccNameStr -> [RawMatch] -> t
 funBindsWithFixity fixity name matches = bindB $ withPlaceHolder
         (noExt FunBind name'
-            (matchGroup context matches) 
+            (matchGroup context matches)
 #if !MIN_VERSION_ghc(9,0,1)
             WpHole
 #endif
@@ -191,7 +191,7 @@ patBindGRHSs p g =
         $ withPlaceHolder
             (withPlaceHolder
                 (withEpAnnNotUsed PatBind (builtPat p) (mkGRHSs g)))
-#if !MIN_VERSION_ghc(9,6,0)                
+#if !MIN_VERSION_ghc(9,6,0)
         $ ([],[])
 #endif
 

--- a/src/GHC/SourceGen/Binds.hs
+++ b/src/GHC/SourceGen/Binds.hs
@@ -106,7 +106,9 @@ funBindsWithFixity fixity name matches = bindB $ withPlaceHolder
             WpHole
 #endif
             )
+#if !MIN_VERSION_ghc(9,6,0)
         []
+#endif
   where
     name' = valueRdrName $ unqual name
     occ = valueOccName name
@@ -189,7 +191,9 @@ patBindGRHSs p g =
         $ withPlaceHolder
             (withPlaceHolder
                 (withEpAnnNotUsed PatBind (builtPat p) (mkGRHSs g)))
+#if !MIN_VERSION_ghc(9,6,0)                
         $ ([],[])
+#endif
 
 -- | Defines a pattern binding without any guards.
 --

--- a/src/GHC/SourceGen/Binds/Internal.hs
+++ b/src/GHC/SourceGen/Binds/Internal.hs
@@ -24,7 +24,6 @@ import PlaceHolder (PlaceHolder(..))
 
 import GHC.SourceGen.Pat.Internal (parenthesize)
 import GHC.SourceGen.Syntax.Internal
-import GHC (noExtField, NoExtField (NoExtField))
 
 -- | A binding definition inside of a @let@ or @where@ clause.
 --

--- a/src/GHC/SourceGen/Binds/Internal.hs
+++ b/src/GHC/SourceGen/Binds/Internal.hs
@@ -24,6 +24,7 @@ import PlaceHolder (PlaceHolder(..))
 
 import GHC.SourceGen.Pat.Internal (parenthesize)
 import GHC.SourceGen.Syntax.Internal
+import GHC (noExtField, NoExtField (NoExtField))
 
 -- | A binding definition inside of a @let@ or @where@ clause.
 --
@@ -83,12 +84,19 @@ data RawGRHSs = RawGRHSs
 
 matchGroup :: HsMatchContext' -> [RawMatch] -> MatchGroup' LHsExpr'
 matchGroup context matches =
-    noExt MG (mkLocated $ map (mkLocated . mkMatch) matches)
+#if MIN_VERSION_ghc(9,6,0)
+    MG Generated
+#else
+    noExt MG
+#endif
+                            matches'
 #if !MIN_VERSION_ghc(8,6,0)
                             [] PlaceHolder
-#endif
+#elif !MIN_VERSION_ghc(9,6,0)
                             Generated
+#endif                            
   where
+    matches' = mkLocated $ map (mkLocated . mkMatch) matches
     mkMatch :: RawMatch -> Match' LHsExpr'
     mkMatch r = withEpAnnNotUsed Match context
                     (map builtPat $ map parenthesize $ rawMatchPats r)

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -51,10 +51,20 @@ module GHC.SourceGen.Decl
     , patSynBind
     ) where
 
+#if MIN_VERSION_ghc(9,0,0) && !MIN_VERSION_ghc(9,6,0)
+import GHC.Types.SrcLoc (LayoutInfo(..))
+#endif
 #if MIN_VERSION_ghc(9,0,0)
 import GHC (LexicalFixity(Prefix))
 import GHC.Data.Bag (listToBag)
+
+#if MIN_VERSION_ghc(9,6,0)
+import GHC (GhcPs, LayoutInfo (NoLayoutInfo))
+#else
+import GHC (GhcPs)
 import GHC.Types.SrcLoc (LayoutInfo(..))
+#endif
+
 #else
 import BasicTypes (LexicalFixity(Prefix))
 import Bag (listToBag)
@@ -62,7 +72,6 @@ import Bag (listToBag)
 #if !MIN_VERSION_ghc(8,6,0)
 import BasicTypes (DerivStrategy(..))
 #endif
-import GHC (GhcPs)
 import GHC.Hs.Binds
 import GHC.Hs.Decls
 
@@ -108,6 +117,7 @@ import GHC.SourceGen.Name
 import GHC.SourceGen.Name.Internal
 import GHC.SourceGen.Syntax.Internal
 import GHC.SourceGen.Type.Internal
+import GHC.Hs
 
 -- | A definition that can appear in the body of a @class@ declaration.
 --
@@ -174,7 +184,10 @@ class'
 class' context name vars decls
     = noExt TyClD $ ClassDecl
             { tcdCtxt = toHsContext $ mkLocated $ map mkLocated context
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc(9,6,0)
+            , tcdLayout = NoLayoutInfo
+            , tcdCExt = (EpAnnNotUsed, NoAnnSortKey)
+#elif MIN_VERSION_ghc(9,2,0)
             , tcdCExt = (EpAnnNotUsed, NoAnnSortKey, NoLayoutInfo)
 #elif MIN_VERSION_ghc(9,0,0)
             , tcdCExt = NoLayoutInfo
@@ -323,11 +336,23 @@ newOrDataType newOrData name vars conDecls derivs
         withEpAnnNotUsed DataDecl (typeRdrName $ unqual name)
             (mkQTyVars vars)
             Prefix
-            $ noExt HsDataDefn newOrData
+            $ noExt HsDataDefn
+#if !MIN_VERSION_ghc(9,6,0)
+                newOrData
+#endif
                 cxt
                 Nothing
                 Nothing
+#if MIN_VERSION_ghc(9,6,0)
+                (case newOrData of
+                    NewType -> case conDecls of
+                        [decl] -> NewTypeCon $ mkLocated decl
+                        _ -> error "NewTypeCon with more than one decl"
+                    DataType -> DataTypeCons False (map mkLocated conDecls)
+                )  
+#else
                 (map mkLocated conDecls)
+#endif
 #if MIN_VERSION_ghc(9,4,0)
                 (toHsDeriving $ map mkLocated derivs)
 #else

--- a/src/GHC/SourceGen/Decl.hs
+++ b/src/GHC/SourceGen/Decl.hs
@@ -51,9 +51,6 @@ module GHC.SourceGen.Decl
     , patSynBind
     ) where
 
-#if MIN_VERSION_ghc(9,0,0) && !MIN_VERSION_ghc(9,6,0)
-import GHC.Types.SrcLoc (LayoutInfo(..))
-#endif
 #if MIN_VERSION_ghc(9,0,0)
 import GHC (LexicalFixity(Prefix))
 import GHC.Data.Bag (listToBag)
@@ -61,8 +58,7 @@ import GHC.Data.Bag (listToBag)
 #if MIN_VERSION_ghc(9,6,0)
 import GHC (GhcPs, LayoutInfo (NoLayoutInfo))
 #else
-import GHC (GhcPs)
-import GHC.Types.SrcLoc (LayoutInfo(..))
+import GHC.Types.SrcLoc (LayoutInfo(NoLayoutInfo))
 #endif
 
 #else

--- a/src/GHC/SourceGen/Expr.hs
+++ b/src/GHC/SourceGen/Expr.hs
@@ -29,11 +29,11 @@ module GHC.SourceGen.Expr
     ) where
 
 import GHC.Hs.Expr
-import GHC.Hs.Extension (GhcPs
+import GHC.Hs.Extension (GhcPs)
 #if MIN_VERSION_ghc(9,6,0)
-                         , noHsTok
+import GHC.Hs.Extension (noHsTok)
+import GHC.Types.SourceText (SourceText(NoSourceText))
 #endif
-                        )
 #if MIN_VERSION_ghc(9,4,0)
 import GHC.Hs.Pat (HsFieldBind(..), HsRecFields(..))
 #else
@@ -62,7 +62,6 @@ import GHC.SourceGen.Type.Internal
     , sigWcType
     , wcType
     )
-import GHC.Types.SourceText (SourceText(NoSourceText))
 
 -- | An overloaded label, as used with the @OverloadedLabels@ extension.
 --

--- a/src/GHC/SourceGen/Expr.hs
+++ b/src/GHC/SourceGen/Expr.hs
@@ -29,7 +29,11 @@ module GHC.SourceGen.Expr
     ) where
 
 import GHC.Hs.Expr
-import GHC.Hs.Extension (GhcPs)
+import GHC.Hs.Extension (GhcPs
+#if MIN_VERSION_ghc(9,6,0)
+                         , noHsTok
+#endif
+                        )
 #if MIN_VERSION_ghc(9,4,0)
 import GHC.Hs.Pat (HsFieldBind(..), HsRecFields(..))
 #else
@@ -58,6 +62,7 @@ import GHC.SourceGen.Type.Internal
     , sigWcType
     , wcType
     )
+import GHC.Types.SourceText (SourceText(NoSourceText))
 
 -- | An overloaded label, as used with the @OverloadedLabels@ extension.
 --
@@ -67,7 +72,9 @@ import GHC.SourceGen.Type.Internal
 overLabel :: String -> HsExpr'
 overLabel = hsOverLabel . fromString
   where
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc(9,6,0)
+    hsOverLabel = withEpAnnNotUsed HsOverLabel NoSourceText
+#elif MIN_VERSION_ghc(9,2,0)
     hsOverLabel = withEpAnnNotUsed HsOverLabel
 #else
     hsOverLabel = noExt HsOverLabel Nothing
@@ -198,7 +205,9 @@ e @::@ t = ExprWithTySig (builtLoc e) (sigWcType t)
 -- > =====
 -- > var "f" @@ var "Int"
 tyApp :: HsExpr' -> HsType' -> HsExpr'
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc(9,6,0)
+tyApp e t = noExt HsAppType e' noHsTok t'
+#elif MIN_VERSION_ghc(9,2,0)
 tyApp e t = HsAppType builtSpan e' t'
 #elif MIN_VERSION_ghc(8,8,0)
 tyApp e t = noExt HsAppType e' t'

--- a/src/GHC/SourceGen/Module.hs
+++ b/src/GHC/SourceGen/Module.hs
@@ -27,9 +27,11 @@ module GHC.SourceGen.Module
     )  where
 
 import GHC.Hs.ImpExp
-    ( LIEWrappedName, IEWildcard(..), IEWrappedName(..), IE(..)
+    ( IEWildcard(..), IEWrappedName(..), IE(..)
 #if MIN_VERSION_ghc(9,6,0)
     , ImportListInterpretation (EverythingBut, Exactly), XImportDeclPass (ideclSourceText, ideclImplicit)
+#else
+    , LIEWrappedName
 #endif
     )
 import GHC.Hs
@@ -59,12 +61,16 @@ import GHC.Types.PkgQual (RawPkgQual(..))
 #endif
 
 import GHC.SourceGen.Syntax.Internal
-import GHC.SourceGen.Name
-    ( RdrNameStr, ModuleNameStr(unModuleNameStr), OccNameStr, unqual )
 import GHC.SourceGen.Name.Internal
 import GHC.SourceGen.Lit.Internal (noSourceText)
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.SourceGen.Name (unqual)
+#endif
+#if MIN_VERSION_ghc(9,4,0)
+import GHC.SourceGen.Name (RdrNameStr, ModuleNameStr(unModuleNameStr), OccNameStr)
 import GHC.Types.SourceText (SourceText(NoSourceText))
 import GHC.Types.SrcLoc (GenLocated)
+#endif
 
 module'
     :: Maybe ModuleNameStr

--- a/src/GHC/SourceGen/Module.hs
+++ b/src/GHC/SourceGen/Module.hs
@@ -113,7 +113,7 @@ import' m = importDecl
 #if MIN_VERSION_ghc(9,4,0)
             NoRawPkgQual
 #else
-            Nothing 
+            Nothing
 #endif
 #if MIN_VERSION_ghc(9,0,0)
             NotBoot
@@ -132,14 +132,14 @@ import' m = importDecl
             Nothing Nothing
   where
 #if MIN_VERSION_ghc(9,6,0)
-    importDecl = ImportDecl 
+    importDecl = ImportDecl
             (XImportDeclPass{ ideclAnn = EpAnnNotUsed
             , ideclSourceText = NoSourceText
             , ideclImplicit = False
              })
 #else
     importDecl = noSourceText (withEpAnnNotUsed ImportDecl)
-#endif 
+#endif
 
 exposing :: ImportDecl' -> [IE'] -> ImportDecl'
 exposing d ies = d

--- a/src/GHC/SourceGen/Module.hs
+++ b/src/GHC/SourceGen/Module.hs
@@ -26,7 +26,12 @@ module GHC.SourceGen.Module
     , moduleContents
     )  where
 
-import GHC.Hs.ImpExp (LIEWrappedName, IEWildcard(..), IEWrappedName(..), IE(..))
+import GHC.Hs.ImpExp
+    ( LIEWrappedName, IEWildcard(..), IEWrappedName(..), IE(..)
+#if MIN_VERSION_ghc(9,6,0)
+    , ImportListInterpretation (EverythingBut, Exactly), XImportDeclPass (ideclSourceText, ideclImplicit)
+#endif
+    )
 import GHC.Hs
     ( HsModule(..)
     , ImportDecl(..)
@@ -36,9 +41,14 @@ import GHC.Hs
 #if MIN_VERSION_ghc(9,2,0)
     , EpAnn(..)
 #endif
+#if MIN_VERSION_ghc(9,6,0)
+    , hsmodDeprecMessage, hsmodHaddockModHeader, hsmodAnn, AnnKeywordId, XModulePs (XModulePs, hsmodLayout), noAnn, LayoutInfo (NoLayoutInfo), GhcPs, XImportDeclPass (XImportDeclPass, ideclAnn), SrcSpanAnnA, noExtField
+#endif
     )
-#if MIN_VERSION_ghc(9,0,0)
+#if MIN_VERSION_ghc(9,0,0) && !MIN_VERSION_ghc(9,6,0)
 import GHC.Types.SrcLoc (LayoutInfo(..))
+#endif
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Unit.Module (IsBootInterface(..))
 import GHC.Types.Name.Reader (RdrName)
 #else
@@ -50,8 +60,11 @@ import GHC.Types.PkgQual (RawPkgQual(..))
 
 import GHC.SourceGen.Syntax.Internal
 import GHC.SourceGen.Name
+    ( RdrNameStr, ModuleNameStr(unModuleNameStr), OccNameStr, unqual )
 import GHC.SourceGen.Name.Internal
 import GHC.SourceGen.Lit.Internal (noSourceText)
+import GHC.Types.SourceText (SourceText(NoSourceText))
+import GHC.Types.SrcLoc (GenLocated)
 
 module'
     :: Maybe ModuleNameStr
@@ -64,13 +77,21 @@ module' name exports imports decls = HsModule
     , hsmodExports = fmap (mkLocated . map mkLocated) exports
     , hsmodImports = map mkLocated imports
     , hsmodDecls = fmap mkLocated decls
+#if MIN_VERSION_ghc(9,6,0)
+    , hsmodExt = XModulePs
+      { hsmodAnn = noAnn
+      , hsmodLayout = NoLayoutInfo
+      , hsmodDeprecMessage = Nothing
+      , hsmodHaddockModHeader = Nothing }
+#else
     , hsmodDeprecMessage = Nothing
     , hsmodHaddockModHeader = Nothing
-#if MIN_VERSION_ghc(9,0,0)
+#  if MIN_VERSION_ghc(9,0,0)
     , hsmodLayout = NoLayoutInfo
-#endif
-#if MIN_VERSION_ghc(9,2,0)
+#  endif
+#  if MIN_VERSION_ghc(9,2,0)
     , hsmodAnn = EpAnnNotUsed
+#  endif
 #endif
     }
 
@@ -87,7 +108,7 @@ as' :: ImportDecl' -> ModuleNameStr -> ImportDecl'
 as' d m = d { ideclAs = Just (mkLocated $ unModuleNameStr m) }
 
 import' :: ModuleNameStr -> ImportDecl'
-import' m = noSourceText (withEpAnnNotUsed ImportDecl)
+import' m = importDecl
             (mkLocated $ unModuleNameStr m)
 #if MIN_VERSION_ghc(9,4,0)
             NoRawPkgQual
@@ -105,15 +126,36 @@ import' m = noSourceText (withEpAnnNotUsed ImportDecl)
 #else
             False
 #endif
-            False Nothing Nothing
+#if !MIN_VERSION_ghc(9,6,0)
+            False
+#endif
+            Nothing Nothing
+  where
+#if MIN_VERSION_ghc(9,6,0)
+    importDecl = ImportDecl 
+            (XImportDeclPass{ ideclAnn = EpAnnNotUsed
+            , ideclSourceText = NoSourceText
+            , ideclImplicit = False
+             })
+#else
+    importDecl = noSourceText (withEpAnnNotUsed ImportDecl)
+#endif 
 
 exposing :: ImportDecl' -> [IE'] -> ImportDecl'
 exposing d ies = d
+#if MIN_VERSION_ghc(9,6,0)
+    { ideclImportList = Just (Exactly, mkLocated $ map mkLocated ies) }
+#else
     { ideclHiding = Just (False, mkLocated $ map mkLocated ies) }
+#endif
 
 hiding :: ImportDecl' -> [IE'] -> ImportDecl'
 hiding d ies = d
+#if MIN_VERSION_ghc(9,6,0)
+    { ideclImportList = Just (EverythingBut, mkLocated $ map mkLocated ies) }
+#else
     { ideclHiding = Just (True, mkLocated $ map mkLocated ies) }
+#endif
 
 -- | Adds the @{-# SOURCE #-}@ pragma to an import.
 source :: ImportDecl' -> ImportDecl'
@@ -150,8 +192,13 @@ thingWith n cs = withEpAnnNotUsed IEThingWith (wrappedName n) NoIEWildcard
 
 -- TODO: support "mixed" syntax with both ".." and explicit names.
 
+#if MIN_VERSION_ghc(9,6,0)
+wrappedName :: RdrNameStr -> GenLocated SrcSpanAnnA (IEWrappedName GhcPs)
+wrappedName rNameStr = mkLocated (IEName noExtField $ exportRdrName rNameStr)
+#else
 wrappedName :: RdrNameStr -> LIEWrappedName RdrName
 wrappedName = mkLocated . IEName . exportRdrName
+#endif
 
 -- | Exports an entire module.
 --

--- a/src/GHC/SourceGen/Overloaded.hs
+++ b/src/GHC/SourceGen/Overloaded.hs
@@ -22,7 +22,11 @@ import GHC.Hs.Type
     ( HsType(..)
     , HsTyVarBndr(..)
     )
-import GHC.Hs (IE(..), IEWrappedName(..), noExtField)
+import GHC.Hs (IE(..), IEWrappedName(..)
+#if MIN_VERSION_ghc(9,6,0)
+    , noExtField
+#endif
+    )
 #if !MIN_VERSION_ghc(8,6,0)
 import PlaceHolder(PlaceHolder(..))
 #endif

--- a/src/GHC/SourceGen/Overloaded.hs
+++ b/src/GHC/SourceGen/Overloaded.hs
@@ -22,7 +22,7 @@ import GHC.Hs.Type
     ( HsType(..)
     , HsTyVarBndr(..)
     )
-import GHC.Hs (IE(..), IEWrappedName(..))
+import GHC.Hs (IE(..), IEWrappedName(..), noExtField)
 #if !MIN_VERSION_ghc(8,6,0)
 import PlaceHolder(PlaceHolder(..))
 #endif
@@ -286,7 +286,14 @@ instance BVar HsTyVarBndr' where
 #endif
 
 instance Var IE' where
-    var n = noExt IEVar $ mkLocated $ IEName $ exportRdrName n
+    var n =
+      noExt IEVar $ mkLocated $
+#if MIN_VERSION_ghc(9,6,0)      
+      (IEName noExtField)
+#else
+      IEName
+#endif
+      $ exportRdrName n
 
 instance BVar IE' where
     bvar = var . UnqualStr

--- a/src/GHC/SourceGen/Overloaded.hs
+++ b/src/GHC/SourceGen/Overloaded.hs
@@ -288,7 +288,7 @@ instance BVar HsTyVarBndr' where
 instance Var IE' where
     var n =
       noExt IEVar $ mkLocated $
-#if MIN_VERSION_ghc(9,6,0)      
+#if MIN_VERSION_ghc(9,6,0)
       (IEName noExtField)
 #else
       IEName
@@ -297,4 +297,3 @@ instance Var IE' where
 
 instance BVar IE' where
     bvar = var . UnqualStr
-

--- a/src/GHC/SourceGen/Pat.hs
+++ b/src/GHC/SourceGen/Pat.hs
@@ -29,6 +29,9 @@ import GHC.SourceGen.Type.Internal (patSigType)
 #if MIN_VERSION_ghc(9,2,0)
 import GHC.Parser.Annotation (EpAnn(..))
 #endif
+#if MIN_VERSION_ghc(9,6,0)
+import GHC (noHsTok)
+#endif
 
 -- | A wild pattern (@_@).
 wildP :: Pat'
@@ -40,7 +43,12 @@ wildP = noExtOrPlaceHolder WildPat
 -- > =====
 -- > asP "a" (var "B")
 asP :: RdrNameStr -> Pat' -> Pat'
-v `asP` p = withEpAnnNotUsed AsPat (valueRdrName v) $ builtPat $ parenthesize p
+v `asP` p =
+  withEpAnnNotUsed AsPat (valueRdrName v)
+#if MIN_VERSION_ghc(9,6,0)
+  noHsTok
+#endif
+  (builtPat $ parenthesize p)
 
 -- | A pattern constructor.
 --

--- a/src/GHC/SourceGen/Syntax/Internal.hs
+++ b/src/GHC/SourceGen/Syntax/Internal.hs
@@ -290,7 +290,7 @@ type HsTyVarBndrS' = HsTyVarBndr GhcPs
 #endif
 
 type HsLit' = HsLit GhcPs
-#if MIN_VERSION_ghc(9,0,0)
+#if MIN_VERSION_ghc(9,0,0) && !MIN_VERSION_ghc(9,6,0)
 type HsModule' = HsModule
 #else
 type HsModule' = HsModule GhcPs

--- a/src/GHC/SourceGen/Syntax/Internal.hs
+++ b/src/GHC/SourceGen/Syntax/Internal.hs
@@ -62,7 +62,7 @@ import RdrName (RdrName)
 import SrcLoc (SrcSpan, Located, GenLocated(..), mkGeneralSrcSpan)
 #endif
 
-#if MIN_VERSION_ghc(9,2,0)
+#if MIN_VERSION_ghc(9,2,0) && !MIN_VERSION_ghc(9,6,0)
 import GHC.Parser.Annotation
     ( SrcSpanAnn'(..)
     , AnnSortKey(..)

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -11,4 +11,4 @@ packages:
 - ghc-show-ast
 
 ghc-options:
-  "$locals": -Wall -Werror
+  "$locals": -Wall -Werror -Wwarn=unused-imports -Wwarn=dodgy-imports

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -12,4 +12,4 @@ packages:
 - ghc-show-ast
 
 ghc-options:
-  "$locals": -Wall -Werror
+  "$locals": -Wall -Werror -Wwarn=unused-imports -Wwarn=dodgy-imports

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -4,8 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: nightly-2022-08-19
-compiler: ghc-9.2.4
+resolver: lts-20.26
+compiler: ghc-9.2.8
 
 packages:
 - .

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -12,4 +12,4 @@ packages:
 - ghc-show-ast
 
 ghc-options:
-  "$locals": -Wall -Werror
+  "$locals": -Wall -Werror -Wwarn=unused-imports -Wwarn=dodgy-imports

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -1,0 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+resolver: lts-21.25
+compiler: ghc-9.4.8
+
+packages:
+- .
+- ghc-show-ast
+
+ghc-options:
+  "$locals": -Wall -Werror

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,0 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+resolver: nightly-2023-11-21
+compiler: ghc-9.6.3
+
+packages:
+- .
+- ghc-show-ast
+
+ghc-options:
+  "$locals": -Wall -Werror

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -12,4 +12,4 @@ packages:
 - ghc-show-ast
 
 ghc-options:
-  "$locals": -Wall -Werror
+  "$locals": -Wall -Werror -Wwarn=unused-imports -Wwarn=dodgy-imports


### PR DESCRIPTION
~Note, this is based on PR #102~ 

- Bump ghc version bounds for GHC 9.6
- Support GHC 9.6

I did run `cabal test` with GHC 9.2.8, 9.4.6 and 9.6.2.

_Note_: using this with proto-lens-protoc, results in an Access Violation on Windows:
```
ERROR: D:/a/rules_haskell/rules_haskell/rule_info/BUILD.bazel:4:14: HaskellProtoc rule_info/Proto/RuleInfo.hs failed: (Exit 1): protoc.cmd failed: error executing command (from target //rule_info:rule_info_proto) 
  cd /d C:/_bzl/minshlu6/execroot/rules_haskell
  SET RULES_HASKELL_DOCDIR_PATH=external/rules_haskell_ghc_windows_amd64/doc/html/libraries/base-4.18.0.0
    SET RULES_HASKELL_GHC_PATH=external/rules_haskell_ghc_windows_amd64/bin/ghc-9.6.2.exe
    SET RULES_HASKELL_GHC_PKG_PATH=external/rules_haskell_ghc_windows_amd64/bin/ghc-pkg-9.6.2.exe
    SET RULES_HASKELL_LIBDIR_PATH=external/rules_haskell_ghc_windows_amd64/lib
  bazel-out\x64_windows-opt-exec-2B5CBBC6\bin\tests\protoc.cmd --plugin=protoc-gen-haskell=bazel-out/x64_windows-opt-exec-2B5CBBC6/bin/external/stackage/proto-lens-protoc-0.7.1.1/_install/bin/proto-lens-protoc.exe -Irule_info.proto=bazel-out/x64_windows-fastbuild/bin/rule_info/_virtual_imports/rule_info_proto/rule_info.proto bazel-out/x64_windows-fastbuild/bin/rule_info/_virtual_imports/rule_info_proto/rule_info.proto --proto_path=bazel-out/x64_windows-fastbuild/bin/rule_info/_virtual_imports/rule_info_proto --haskell_out=no-runtime:bazel-out/x64_windows-fastbuild/bin/rule_info
# Configuration: 58805939f72ec32a9a01431f857cb944cd1989989a33202e99fc6941d5e9061b
# Execution platform: @local_config_platform//:host

Access violation in generated code when executing data at 0x7ff72099960d

 Attempting to reconstruct a stack trace...

   Frame	Code address
 * 0x1f5c70d5f0	0x7ff72099960d
 * 0x1f5c70d5f8	0x7ff800000a77
 * 0x1f5c70d600	0x1645e17f5d0

--haskell_out: protoc-gen-haskell: Plugin failed with status code 11.
```
I am not sure this is related to this change...