### PR TITLE
import of unqual shouldn't be conditional on ghc version; it's used unconditionally

### DIFF
--- a/src/GHC/SourceGen/Module.hs
+++ b/src/GHC/SourceGen/Module.hs
@@ -63,9 +63,7 @@ import GHC.Types.PkgQual (RawPkgQual(..))
 import GHC.SourceGen.Syntax.Internal
 import GHC.SourceGen.Name.Internal
 import GHC.SourceGen.Lit.Internal (noSourceText)
-#if MIN_VERSION_ghc(9,0,0)
 import GHC.SourceGen.Name (unqual)
-#endif
 #if MIN_VERSION_ghc(9,4,0)
 import GHC.SourceGen.Name (RdrNameStr, ModuleNameStr(unModuleNameStr), OccNameStr)
 import GHC.Types.SourceText (SourceText(NoSourceText))


### PR DESCRIPTION
Needed to correct a build failure on GHC 8.10.

I've checked that it builds and the tests pass on GHC 9.6.4 as well.

Fixes #109