### PR TITLE
Fix #112 with support for GHC 9.8

### DIFF
--- a/ghc-source-gen.cabal
+++ b/ghc-source-gen.cabal
@@ -106,7 +106,7 @@ test-suite name_test
     , base >=4.7 && <5
     , ghc >=8.4 && <9.9
     , ghc-source-gen
-    , tasty >=1.0 && <1.5
+    , tasty >=1.0 && <1.6
     , tasty-hunit ==0.10.*
     , tasty-quickcheck >=0.9 && <0.11
   default-language: Haskell2010
@@ -128,7 +128,7 @@ test-suite pprint_examples
     , ghc >=8.4 && <9.9
     , ghc-paths ==0.1.*
     , ghc-source-gen
-    , tasty >=1.0 && <1.5
+    , tasty >=1.0 && <1.6
     , tasty-hunit ==0.10.*
   default-language: Haskell2010
   if impl(ghc<9.0)
@@ -154,7 +154,7 @@ test-suite pprint_test
     , ghc >=8.4 && <9.9
     , ghc-paths ==0.1.*
     , ghc-source-gen
-    , tasty >=1.0 && <1.5
+    , tasty >=1.0 && <1.6
     , tasty-hunit ==0.10.*
   default-language: Haskell2010
   if impl(ghc<9.0)

--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ description: |
 
 dependencies:
 - base >= 4.7 && < 5
-- ghc >= 8.4 && < 9.7
+- ghc >= 8.4 && < 9.9
 
 default-extensions:
 - DataKinds
@@ -84,7 +84,7 @@ tests:
     dependencies:
     - ghc-source-gen
     - ghc-paths == 0.1.*
-    - tasty >= 1.0 && < 1.5
+    - tasty >= 1.0 && < 1.6
     - tasty-hunit == 0.10.*
 
     when:
@@ -100,7 +100,7 @@ tests:
     dependencies:
     - ghc-source-gen
     - ghc-paths == 0.1.*
-    - tasty >= 1.0 && < 1.5
+    - tasty >= 1.0 && < 1.6
     - tasty-hunit == 0.10.*
 
     when:
@@ -117,6 +117,6 @@ tests:
     dependencies:
     - ghc-source-gen
     - QuickCheck >= 2.10 && < 2.15
-    - tasty >= 1.0 && < 1.5
+    - tasty >= 1.0 && < 1.6
     - tasty-hunit == 0.10.*
     - tasty-quickcheck >= 0.9 && < 0.11

--- a/src/GHC/SourceGen/Module.hs
+++ b/src/GHC/SourceGen/Module.hs
@@ -219,5 +219,14 @@ moduleContents = withEpAnnNotUsed' IEModuleContents . mkLocated . unModuleNameSt
 withEpAnnNotUsed' :: ((Maybe x, EpAnn ann) -> a) -> a
 withEpAnnNotUsed' = ($ (Nothing, EpAnnNotUsed))
 #else
+
+#if MIN_VERSION_ghc(9,2,0)
+withEpAnnNotUsed' :: (EpAnn ann -> a) -> a
+#elif MIN_VERSION_ghc(8,6,0)
+withEpAnnNotUsed' :: (NoExtField -> a) -> a
+#else
+withEpAnnNotUsed' :: a -> a
+#endif
 withEpAnnNotUsed' = withEpAnnNotUsed
+
 #endif

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,0 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+resolver: nightly-2024-03-29
+compiler: ghc-9.8.2
+
+packages:
+- .
+- ghc-show-ast
+
+ghc-options:
+  "$locals": -Wall -Werror -Wwarn=unused-imports -Wwarn=dodgy-imports


### PR DESCRIPTION
* Add missing annotation for `withEpAnnNotUsed`

* Add `stack-9.8.yaml`

* Bump tasty to `< 1.6` rather than `<1.5` due to:
```
tasty must match >=1.0 && <1.5, but tasty-1.5 is in the Stack configuration (latest matching version is 1.4.3).
```